### PR TITLE
Reduce maximum sugarscape agent population to match 0.xml

### DIFF
--- a/examples/Sugarscape/src/model/XMLModelFile.xml
+++ b/examples/Sugarscape/src/model/XMLModelFile.xml
@@ -132,7 +132,7 @@
       </states>
       
       <gpu:type>discrete</gpu:type>
-      <gpu:bufferSize>1048576</gpu:bufferSize>
+      <gpu:bufferSize>65536</gpu:bufferSize>
     </gpu:xagent>
   </xagents>
   
@@ -156,7 +156,7 @@
       <gpu:partitioningDiscrete>
         <gpu:radius>1</gpu:radius>
       </gpu:partitioningDiscrete>
-      <gpu:bufferSize>1048576</gpu:bufferSize>
+      <gpu:bufferSize>65536</gpu:bufferSize>
     </gpu:message>
     
     <gpu:message>
@@ -182,7 +182,7 @@
       <gpu:partitioningDiscrete>
         <gpu:radius>1</gpu:radius>
       </gpu:partitioningDiscrete>
-      <gpu:bufferSize>1048576</gpu:bufferSize>
+      <gpu:bufferSize>65536</gpu:bufferSize>
     </gpu:message>
     
     <gpu:message>
@@ -200,7 +200,7 @@
       <gpu:partitioningDiscrete>
         <gpu:radius>1</gpu:radius>
       </gpu:partitioningDiscrete>
-      <gpu:bufferSize>1048576</gpu:bufferSize>
+      <gpu:bufferSize>65536</gpu:bufferSize>
     </gpu:message>
     
     


### PR DESCRIPTION
This fixes the visualisation for the included example, and likely also behaviour.

The simpler of 2 solutions for #22.
The alternative of fixing the issue to allow a dynamic population sizes at run time up to the maximum at compile time would be non-trivial.