### PR TITLE
Expose the inputfile and outputpath variables outside of main.cu

### DIFF
--- a/FLAMEGPU/templates/header.xslt
+++ b/FLAMEGPU/templates/header.xslt
@@ -70,6 +70,9 @@ typedef unsigned int uint;
 #define xmachine_message_<xsl:value-of select="xmml:name"/>_grid_size <xsl:value-of select="$x_dim * $y_dim * $z_dim"/>
 </xsl:if></xsl:for-each>
   
+/* IO Variables*/
+extern char inputfile[100];          /**&lt; Input path char buffer*/
+extern char outputpath[100];         /**&lt; Output path char buffer*/
   
 /* enum types */
 


### PR DESCRIPTION
Getting the directory which contains the inputfile (output path) can be useful in functions.c.
By extern-ing these variables in header.h they are available everywhere.