### PR TITLE
Rc1.5/visualisation pause

### DIFF
--- a/FLAMEGPU/templates/visualisation.xslt
+++ b/FLAMEGPU/templates/visualisation.xslt
@@ -51,6 +51,13 @@ int mouse_buttons = 0;
 float rotate_x = 0.0, rotate_y = 0.0;
 float translate_z = -VIEW_DISTANCE;
 
+// keyboard controls
+#if defined(PAUSE_ON_START)
+bool paused = true;
+#else
+bool paused = false;
+#endif
+
 // vertex Shader
 GLuint vertexShader;
 GLuint fragmentShader;
@@ -81,6 +88,7 @@ void deleteTBO( GLuint* tbo);
 void setVertexBufferData();
 void display();
 void keyboard( unsigned char key, int x, int y);
+void special(int key, int x, int y);
 void mouse(int button, int state, int x, int y);
 void motion(int x, int y);
 void runCuda();
@@ -224,6 +232,7 @@ void initVisualisation()
 	// register callbacks
 	glutDisplayFunc( display);
 	glutKeyboardFunc( keyboard);
+	glutSpecialFunc( special);
 	glutMouseFunc( mouse);
 	glutMotionFunc( motion);
     
@@ -254,6 +263,7 @@ void runVisualisation(){
 ////////////////////////////////////////////////////////////////////////////////
 void runCuda()
 {
+	if(!paused){
 #ifdef SIMULATION_DELAY
 	delay_count++;
 	if (delay_count == SIMULATION_DELAY){
@@ -263,6 +273,7 @@ void runCuda()
 #else
 	singleIteration();
 #endif
+	}
 
 	//kernals sizes
 	int threads_per_tile = 256;
@@ -608,17 +619,36 @@ void display()
 void keyboard( unsigned char key, int /*x*/, int /*y*/)
 {
 	switch( key) {
-	case( 27) :
+	// Space == 32
+    case(32):
+        paused = !paused;
+        break;
+    // Esc == 27
+	case(27) :
 		deleteVBO( &amp;sphereVerts);
 		deleteVBO( &amp;sphereNormals);
 		<xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent/xmml:states/gpu:state">
 		deleteTBO( &amp;<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_tbo);
 		</xsl:for-each>
 		cudaEventDestroy(start);
-    cudaEventDestroy(stop);
+		cudaEventDestroy(stop);
 		exit(EXIT_SUCCESS);
 	}
 }
+
+
+
+
+void special(int key, int x, int y){
+    switch (key)
+    {
+    case(GLUT_KEY_RIGHT) :
+        singleIteration();
+        fflush(stdout);
+        break;
+    }
+}
+
 
 ////////////////////////////////////////////////////////////////////////////////
 //! Mouse event handlers

--- a/FLAMEGPU/templates/visualisation.xslt
+++ b/FLAMEGPU/templates/visualisation.xslt
@@ -35,6 +35,8 @@
 #include "header.h"
 #include "visualisation.h"
 
+#define FOVY 45.0
+
 // bo variables
 GLuint sphereVerts;
 GLuint sphereNormals;
@@ -86,6 +88,7 @@ void deleteVBO( GLuint* vbo);
 void createTBO( GLuint* tbo, GLuint* tex, GLuint size);
 void deleteTBO( GLuint* tbo);
 void setVertexBufferData();
+void reshape(int width, int height);
 void display();
 void keyboard( unsigned char key, int x, int y);
 void special(int key, int x, int y);
@@ -230,6 +233,7 @@ void initVisualisation()
 	initShader();
 
 	// register callbacks
+	glutReshapeFunc( reshape);
 	glutDisplayFunc( display);
 	glutKeyboardFunc( keyboard);
 	glutSpecialFunc( special);
@@ -333,14 +337,7 @@ int initGL()
 	glClearColor( 1.0, 1.0, 1.0, 1.0);
 	glEnable( GL_DEPTH_TEST);
 
-	// viewport
-	glViewport( 0, 0, WINDOW_WIDTH, WINDOW_HEIGHT);
-
-	// projection
-	glMatrixMode( GL_PROJECTION);
-	glLoadIdentity();
-	gluPerspective(45.0, (GLfloat)WINDOW_WIDTH / (GLfloat) WINDOW_HEIGHT, NEAR_CLIP, FAR_CLIP);
-
+	reshape(WINDOW_WIDTH, WINDOW_HEIGHT);
 	checkGLError();
 
 	//lighting
@@ -530,6 +527,25 @@ void setVertexBufferData()
 		}
     }
 	glUnmapBuffer(GL_ARRAY_BUFFER);
+}
+
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+//! Reshape callback
+////////////////////////////////////////////////////////////////////////////////
+
+void reshape(int width, int height){
+	// viewport
+	glViewport( 0, 0, width, height);
+
+	// projection
+	glMatrixMode( GL_PROJECTION);
+	glLoadIdentity();
+	gluPerspective(FOVY, (GLfloat)width / (GLfloat) height, NEAR_CLIP, FAR_CLIP);
+
+	checkGLError();
 }
 
 

--- a/examples/Boids_Partitioning/src/visualisation/visualisation.h
+++ b/examples/Boids_Partitioning/src/visualisation/visualisation.h
@@ -1,6 +1,7 @@
 #ifndef __VISUALISATION_H
 #define __VISUALISATION_H
 
+#define PAUSE_ON_START
 // constants
 const unsigned int WINDOW_WIDTH = 512;
 const unsigned int WINDOW_HEIGHT = 512;


### PR DESCRIPTION
+ Pausing of simulation
    + `space` to pause the simulation
    + `->` (right arrow) to step a single iteration
    + `#define PAUSE_ON_START` in `visualisation.h` to pause before the first iteration.
+  Window Reshaping
    + uses `glutReshapeFunc` to enable reshaping of the window without content distortion!

For now I have omitted the "Y is up" option, as it's not necessary and if anyone is going down that route they will probably have a custom visualisation anyway.

![boids-paused](https://cloud.githubusercontent.com/assets/628937/26729778/9f4d3016-47a6-11e7-9681-c961d454aea1.png)
![boids_reshaped](https://cloud.githubusercontent.com/assets/628937/26729781/a0deae28-47a6-11e7-97e3-ff33895b493d.png)
