### PR TITLE
Add Host based agent creation and associated example.

### DIFF
--- a/FLAMEGPU/templates/simulation.xslt
+++ b/FLAMEGPU/templates/simulation.xslt
@@ -702,7 +702,7 @@ xmachine_memory_<xsl:value-of select="$agent_name" />** h_allocate_agent_<xsl:va
 }
 void h_free_agent_<xsl:value-of select="$agent_name" />_array(xmachine_memory_<xsl:value-of select="$agent_name" />*** agents, unsigned int count){
 	for (unsigned int i = 0; i &lt; count; i++) {
-		h_free_agent_Agent(&amp;((*agents)[i]));
+		h_free_agent_<xsl:value-of select="$agent_name" />(&amp;((*agents)[i]));
 	}
 	free((*agents));
 	(*agents) = NULL;

--- a/FLAMEGPU/templates/simulation.xslt
+++ b/FLAMEGPU/templates/simulation.xslt
@@ -661,12 +661,12 @@ void copy_partial_xmachine_memory_<xsl:value-of select="xmml:name"/>_hostToDevic
 		for(unsigned int i = 0; i &lt; <xsl:value-of select="xmml:arrayLength"/>; i++){
 			gpuErrchk(cudaMemcpy(d_dst-&gt;<xsl:value-of select="xmml:name"/> + (i * xmachine_memory_<xsl:value-of select="../../xmml:name" />_MAX), h_src-&gt;<xsl:value-of select="xmml:name"/> + (i * xmachine_memory_<xsl:value-of select="../../xmml:name" />_MAX), count * sizeof(<xsl:value-of select="xmml:type"/>), cudaMemcpyHostToDevice));
         }
-    }
 
 </xsl:if><xsl:if test="not(xmml:arrayLength)"> 
 		gpuErrchk(cudaMemcpy(d_dst-&gt;<xsl:value-of select="xmml:name"/>, h_src-&gt;<xsl:value-of select="xmml:name"/>, count * sizeof(<xsl:value-of select="xmml:type"/>), cudaMemcpyHostToDevice));
 </xsl:if>
 	</xsl:for-each>
+    }
 }
 </xsl:for-each>
 

--- a/FLAMEGPU/templates/simulation.xslt
+++ b/FLAMEGPU/templates/simulation.xslt
@@ -673,16 +673,12 @@ void copy_partial_xmachine_memory_<xsl:value-of select="xmml:name"/>_hostToDevic
 <xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent"><xsl:variable name="agent_name" select="xmml:name"/>
 xmachine_memory_<xsl:value-of select="$agent_name" />* h_allocate_agent_<xsl:value-of select="$agent_name" />(){
 	xmachine_memory_<xsl:value-of select="$agent_name" />* agent = (xmachine_memory_<xsl:value-of select="$agent_name" />*)malloc(sizeof(xmachine_memory_<xsl:value-of select="$agent_name" />));
+    memset(agent, 0, sizeof(xmachine_memory_<xsl:value-of select="$agent_name" />));
 <xsl:for-each select="xmml:memory/gpu:variable">
-<xsl:choose>
-<xsl:when test="not(xmml:arrayLength)">
-    agent-&gt;<xsl:value-of select="xmml:name"/> = 0;</xsl:when>
-<xsl:otherwise>
+<xsl:if test="xmml:arrayLength">
     agent-&gt;<xsl:value-of select="xmml:name"/> = (<xsl:value-of select="xmml:type"/>*)malloc(<xsl:value-of select="xmml:arrayLength"/> * sizeof(<xsl:value-of select="xmml:type"/>));
-    for(unsigned int i = 0; i &lt; <xsl:value-of select="xmml:arrayLength"/>; i++){
-        agent-&gt;<xsl:value-of select="xmml:name"/>[i] = 0;
-    }</xsl:otherwise>
-</xsl:choose>
+    memset(agent-&gt;<xsl:value-of select="xmml:name"/>, 0, sizeof(<xsl:value-of select="xmml:type"/>)*<xsl:value-of select="xmml:arrayLength"/>);
+</xsl:if>
 </xsl:for-each>
 	return agent;
 }

--- a/bin/x64/HostAgentCreation.bat
+++ b/bin/x64/HostAgentCreation.bat
@@ -1,0 +1,1 @@
+"Release_Console\HostAgentCreation.exe" "..\..\examples\HostAgentCreation\iterations\0.xml" 1

--- a/examples/HostAgentCreation/HostAgentCreation.sln
+++ b/examples/HostAgentCreation/HostAgentCreation.sln
@@ -1,0 +1,20 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "HostAgentCreation", "HostAgentCreation.vcxproj", "{74309752-05AD-471A-B1A3-57EC7526402A}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug_Console|x64 = Debug_Console|x64
+		Release_Console|x64 = Release_Console|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{74309752-05AD-471A-B1A3-57EC7526402A}.Debug_Console|x64.ActiveCfg = Debug_Console|x64
+		{74309752-05AD-471A-B1A3-57EC7526402A}.Debug_Console|x64.Build.0 = Debug_Console|x64
+		{74309752-05AD-471A-B1A3-57EC7526402A}.Release_Console|x64.ActiveCfg = Release_Console|x64
+		{74309752-05AD-471A-B1A3-57EC7526402A}.Release_Console|x64.Build.0 = Release_Console|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/examples/HostAgentCreation/HostAgentCreation.vcxproj
+++ b/examples/HostAgentCreation/HostAgentCreation.vcxproj
@@ -1,0 +1,180 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug_Console|x64">
+      <Configuration>Debug_Console</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release_Console|x64">
+      <Configuration>Release_Console</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{74309752-05AD-471A-B1A3-57EC7526402A}</ProjectGuid>
+    <RootNamespace>HostAgentCreation_</RootNamespace>
+    <ProjectName>HostAgentCreation</ProjectName>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_Console|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_Console|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <FLAMEGPU_Template_Build_RuleAfterTargets>
+    </FLAMEGPU_Template_Build_RuleAfterTargets>
+    <CUDA_Build_RuleAfterTargets>_FLAMEGPU_Template_Build_Rule</CUDA_Build_RuleAfterTargets>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+    <Import Project="$(VCTargetsPath)\BuildCustomizations\CUDA 8.0.props" />
+    <Import Project="../../tools/FLAMEGPU.props" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug_Console|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release_Console|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_Console|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>..\..\bin\$(Platform)\$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_Console|x64'">
+    <OutDir>..\..\bin\$(Platform)\$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug_Console|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;WIN64;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(CudaToolkitIncludeDir);..\..\include;.\src;.\src\model;.\src\dynamic;.\src\visualisation;%(Include)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+      <AdditionalDependencies>cudart.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>../../lib/;%(AdditionalLibraryDirectories);$(CudaToolkitLibDir)</AdditionalLibraryDirectories>
+    </Link>
+    <PostBuildEvent>
+      <Command>echo copy "$(CudaToolkitBinDir)\cudart*.dll" "$(OutDir)"
+copy "$(CudaToolkitBinDir)\cudart*.dll" "$(OutDir)"</Command>
+    </PostBuildEvent>
+    <CudaCompile>
+      <TargetMachinePlatform>64</TargetMachinePlatform>
+      <Include>..\..\include;.\src;.\src\model;.\src\dynamic;.\src\visualisation;%(Include)</Include>
+      <CodeGeneration>compute_30,sm_30;compute_35,sm_35;compute_50,sm_50;compute_60,sm_60</CodeGeneration>
+      <GPUDebugInfo>true</GPUDebugInfo>
+      <GenerateLineInfo>true</GenerateLineInfo>
+      <HostDebugInfo>true</HostDebugInfo>
+      <Runtime>MTd</Runtime>
+      <AdditionalOptions>-Wno-deprecated-gpu-targets %(AdditionalOptions)</AdditionalOptions>
+    </CudaCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release_Console|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PreprocessorDefinitions>WIN32;WIN64;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(CudaToolkitIncludeDir);..\..\include;.\src;.\src\model;.\src\dynamic;.\src\visualisation;%(Include)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <SubSystem>Console</SubSystem>
+      <AdditionalDependencies>cudart.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>../../lib/;%(AdditionalLibraryDirectories);$(CudaToolkitLibDir)</AdditionalLibraryDirectories>
+    </Link>
+    <PostBuildEvent>
+      <Command>echo copy "$(CudaToolkitBinDir)\cudart*.dll" "$(OutDir)"
+copy "$(CudaToolkitBinDir)\cudart*.dll" "$(OutDir)"</Command>
+    </PostBuildEvent>
+    <CudaCompile>
+      <TargetMachinePlatform>64</TargetMachinePlatform>
+      <Include>..\..\include;.\src;.\src\model;.\src\dynamic;.\src\visualisation;%(Include)</Include>
+      <CodeGeneration>compute_30,sm_30;compute_35,sm_35;compute_50,sm_50;compute_60,sm_60</CodeGeneration>
+      <Runtime>MT</Runtime>
+      <Defines>WIN32</Defines>
+      <AdditionalOptions>-Wno-deprecated-gpu-targets %(AdditionalOptions)</AdditionalOptions>
+    </CudaCompile>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="src\dynamic\FLAMEGPU_kernals.cu">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug_Console|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release_Console|x64'">true</ExcludedFromBuild>
+      <FileType>Document</FileType>
+    </ClInclude>
+    <ClInclude Include="src\visualisation\visualisation.h" />
+    <ClInclude Include="XMML.h">
+      <DependentUpon>..\..\FLAMEGPU\schemas\XMML.xsd</DependentUpon>
+    </ClInclude>
+    <ClInclude Include="XMMLGPU.h">
+      <DependentUpon>..\..\FLAMEGPU\schemas\XMMLGPU.xsd</DependentUpon>
+    </ClInclude>
+    <CudaCompile Include="src\dynamic\io.cu" />
+    <CudaCompile Include="src\dynamic\main.cu" />
+    <CudaCompile Include="src\dynamic\simulation.cu" />
+    <CudaCompile Include="src\dynamic\visualisation.cu">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release_Console|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug_Console|x64'">true</ExcludedFromBuild>
+    </CudaCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="src\dynamic\header.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug_Console|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release_Console|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <Text Include="src\dynamic\_README.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="src\model\functions.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release_Console|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug_Console|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <Xml Include="..\..\FLAMEGPU\templates\FLAMEGPU_kernals.xslt" />
+    <Xml Include="..\..\FLAMEGPU\templates\header.xslt" />
+    <Xml Include="..\..\FLAMEGPU\templates\io.xslt" />
+    <Xml Include="..\..\FLAMEGPU\templates\main.xslt" />
+    <Xml Include="..\..\FLAMEGPU\templates\simulation.xslt">
+      <SubType>Designer</SubType>
+    </Xml>
+    <Xml Include="..\..\FLAMEGPU\templates\visualisation.xslt" />
+    <FLAMEGPU_Template_Build_Rule Include="src\model\XMLModelFile.xml">
+      <SubType>Designer</SubType>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release_Console|x64'">false</ExcludedFromBuild>
+    </FLAMEGPU_Template_Build_Rule>
+  </ItemGroup>
+  <ItemGroup>
+    <Xsd Include="..\..\FLAMEGPU\schemas\XMML.xsd">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release_Console|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug_Console|x64'">true</ExcludedFromBuild>
+    </Xsd>
+    <Xsd Include="..\..\FLAMEGPU\schemas\XMMLGPU.xsd">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release_Console|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug_Console|x64'">true</ExcludedFromBuild>
+    </Xsd>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+    <Import Project="$(VCTargetsPath)\BuildCustomizations\CUDA 8.0.targets" />
+    <Import Project="../../tools/FLAMEGPU.targets" />
+  </ImportGroup>
+</Project>

--- a/examples/HostAgentCreation/HostAgentCreation.vcxproj.filters
+++ b/examples/HostAgentCreation/HostAgentCreation.vcxproj.filters
@@ -1,0 +1,90 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <CudaCompile Include="src\dynamic\io.cu">
+      <Filter>dynamic</Filter>
+    </CudaCompile>
+    <CudaCompile Include="src\dynamic\main.cu">
+      <Filter>dynamic</Filter>
+    </CudaCompile>
+    <CudaCompile Include="src\dynamic\simulation.cu">
+      <Filter>dynamic</Filter>
+    </CudaCompile>
+    <CudaCompile Include="src\dynamic\visualisation.cu">
+      <Filter>dynamic</Filter>
+    </CudaCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="XMML.h" />
+    <ClInclude Include="XMMLGPU.h" />
+    <ClInclude Include="src\dynamic\FLAMEGPU_kernals.cu">
+      <Filter>dynamic</Filter>
+    </ClInclude>
+    <ClInclude Include="src\dynamic\header.h">
+      <Filter>dynamic</Filter>
+    </ClInclude>
+    <ClInclude Include="src\visualisation\visualisation.h">
+      <Filter>visualisation</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <Xml Include="..\..\FLAMEGPU\templates\FLAMEGPU_kernals.xslt">
+      <Filter>templates</Filter>
+    </Xml>
+    <Xml Include="..\..\FLAMEGPU\templates\header.xslt">
+      <Filter>templates</Filter>
+    </Xml>
+    <Xml Include="..\..\FLAMEGPU\templates\io.xslt">
+      <Filter>templates</Filter>
+    </Xml>
+    <Xml Include="..\..\FLAMEGPU\templates\main.xslt">
+      <Filter>templates</Filter>
+    </Xml>
+    <Xml Include="..\..\FLAMEGPU\templates\simulation.xslt">
+      <Filter>templates</Filter>
+    </Xml>
+    <Xml Include="..\..\FLAMEGPU\templates\visualisation.xslt">
+      <Filter>templates</Filter>
+    </Xml>
+  </ItemGroup>
+  <ItemGroup>
+    <Filter Include="dynamic">
+      <UniqueIdentifier>{0d1e4764-47ad-4530-833f-9faa04877689}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="model">
+      <UniqueIdentifier>{68a822ce-68b8-40a9-8f05-ff3b9d740f13}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="templates">
+      <UniqueIdentifier>{765ed822-27f7-46a9-95ac-e617b504cc6c}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="schemas">
+      <UniqueIdentifier>{9ce5c34b-314c-4f85-9fe5-afc8093a2049}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="visualisation">
+      <UniqueIdentifier>{19aa7ca1-80be-4c38-97ec-b46c207b3984}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="src\model\functions.c">
+      <Filter>model</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <Text Include="src\dynamic\_README.txt">
+      <Filter>dynamic</Filter>
+    </Text>
+  </ItemGroup>
+  <ItemGroup>
+    <FLAMEGPU_Template_Build_Rule Include="src\model\XMLModelFile.xml">
+      <Filter>model</Filter>
+    </FLAMEGPU_Template_Build_Rule>
+  </ItemGroup>
+  <ItemGroup>
+    <Xsd Include="..\..\FLAMEGPU\schemas\XMML.xsd">
+      <Filter>schemas</Filter>
+    </Xsd>
+    <Xsd Include="..\..\FLAMEGPU\schemas\XMMLGPU.xsd">
+      <Filter>schemas</Filter>
+    </Xsd>
+  </ItemGroup>
+</Project>

--- a/examples/HostAgentCreation/Makefile
+++ b/examples/HostAgentCreation/Makefile
@@ -1,0 +1,293 @@
+################################################################################
+#
+# FLAME GPU Script for CUDA 7.5
+#
+# Copyright 2016 University of Sheffield.  All rights reserved.
+#
+# Authors : Dr Mozhgan Kabiri Chimeh, Dr Paul Richmond
+# Contact : {m.kabiri-chimeh,p.richmond}@sheffield.ac.uk
+#
+# NOTICE TO USER:
+#
+# University of Sheffield retain all intellectual property and
+# proprietary rights in and to this software and related documentation.
+# Any use, reproduction, disclosure, or distribution of this software
+# and related documentation without an express license agreement from
+# University of Sheffield is strictly prohibited.
+#
+# For terms of licence agreement please attached licence or view licence
+# on www.flamegpu.com website.
+#
+################################################################################
+# USAGE : make help
+################################################################################
+#
+# Makefile project only supported on Linux Platforms
+#
+################################################################################
+# Folders containing FLAMEGPU example files and templates
+BIN_DIR := ../../bin/x64/
+ 
+IDIR := ../../include/
+# For now this will only work for x64 linux. 32x is uninportant as deprecated in CUDA 8.0 Other systems are currently not possible to test.
+LDIR := ../../lib/x86_64-linux-gnu/
+TEMPLATE := ../../FLAMEGPU/templates/
+XSD_SCHEMA := ../../FLAMEGPU/schemas/
+
+INPUT_DATA:=iterations/0.xml
+
+SRC_ := src/model/
+SRC_VIZ := src/visualisation/
+SRC_CUDA := src/dynamic/
+
+OPENGL_FLAGS := -lglut -lGLEW -lGLU -lGL
+FLAMELIB := -I $(IDIR) -I $(SRC_) -I $(SRC_CUDA) -I $(SRC_VIZ) -I $(IDIR)GL/
+
+################################################################################
+#Generating Dynamic Code from FLAMEGPU Templates
+
+XML_MODEL:=$(SRC_)XMLModelFile.xml
+
+all: XSLTPREP build
+
+XML_Validate:
+	xmllint --noout $(XML_MODEL) --schema $(XSD_SCHEMA)XMMLGPU.xsd 
+
+XSLTPREP: XML_Validate
+XSLTPREP:
+	xsltproc $(TEMPLATE)header.xslt  $(XML_MODEL)> $(SRC_CUDA)header.h 
+	xsltproc $(TEMPLATE)FLAMEGPU_kernals.xslt $(XML_MODEL) > $(SRC_CUDA)FLAMEGPU_kernals.cu
+	xsltproc $(TEMPLATE)io.xslt $(XML_MODEL) > $(SRC_CUDA)io.cu 
+	xsltproc $(TEMPLATE)simulation.xslt $(XML_MODEL) > $(SRC_CUDA)simulation.cu 
+	xsltproc $(TEMPLATE)main.xslt $(XML_MODEL) > $(SRC_CUDA)main.cu
+
+################################################################################
+
+# Location of the CUDA Toolkit
+CUDA_PATH ?= "/usr/local/cuda-7.5"
+
+# architecture
+HOST_ARCH   := $(shell uname -m)
+TARGET_ARCH ?= $(HOST_ARCH)
+ifneq (,$(filter $(TARGET_ARCH),x86_64 aarch64 ppc64le))
+    TARGET_SIZE := 64
+else ifeq ($(TARGET_ARCH),armv7l)
+    TARGET_SIZE := 32
+else
+    $(error ERROR - unsupported value $(TARGET_ARCH) for TARGET_ARCH!)
+endif
+ifneq ($(TARGET_ARCH),$(HOST_ARCH))
+    ifeq (,$(filter $(HOST_ARCH)-$(TARGET_ARCH),aarch64-armv7l x86_64-armv7l x86_64-aarch64 x86_64-ppc64le))
+        $(error ERROR - cross compiling from $(HOST_ARCH) to $(TARGET_ARCH) is not supported!)
+    endif
+endif
+
+# operating system
+HOST_OS   := $(shell uname -s 2>/dev/null | tr "[:upper:]" "[:lower:]")
+TARGET_OS ?= $(HOST_OS)
+ifeq (,$(filter $(TARGET_OS),linux darwin qnx android))
+    $(error ERROR - unsupported value $(TARGET_OS) for TARGET_OS!)
+endif
+
+# host compiler
+ifeq ($(TARGET_OS),darwin)
+    ifeq ($(shell expr `xcodebuild -version | grep -i xcode | awk '{print $$2}' | cut -d'.' -f1` \>= 5),1)
+        HOST_COMPILER ?= clang++
+    endif
+else ifneq ($(TARGET_ARCH),$(HOST_ARCH))
+    ifeq ($(HOST_ARCH)-$(TARGET_ARCH),x86_64-armv7l)
+        ifeq ($(TARGET_OS),linux)
+            HOST_COMPILER ?= arm-linux-gnueabihf-g++
+        else ifeq ($(TARGET_OS),qnx)
+            ifeq ($(QNX_HOST),)
+                $(error ERROR - QNX_HOST must be passed to the QNX host toolchain)
+            endif
+            ifeq ($(QNX_TARGET),)
+                $(error ERROR - QNX_TARGET must be passed to the QNX target toolchain)
+            endif
+            export QNX_HOST
+            export QNX_TARGET
+            HOST_COMPILER ?= $(QNX_HOST)/usr/bin/arm-unknown-nto-qnx6.6.0eabi-g++
+        else ifeq ($(TARGET_OS),android)
+            HOST_COMPILER ?= arm-linux-androideabi-g++
+        endif
+    else ifeq ($(TARGET_ARCH),aarch64)
+        ifeq ($(TARGET_OS), linux)
+            HOST_COMPILER ?= aarch64-linux-gnu-g++
+        else ifeq ($(TARGET_OS), android)
+            HOST_COMPILER ?= aarch64-linux-android-g++
+        endif
+    else ifeq ($(TARGET_ARCH),ppc64le)
+        HOST_COMPILER ?= powerpc64le-linux-gnu-g++
+    endif
+endif
+HOST_COMPILER ?= g++
+NVCC          := $(CUDA_PATH)/bin/nvcc -ccbin $(HOST_COMPILER)
+
+# internal flags
+NVCCFLAGS   := -m${TARGET_SIZE}
+CCFLAGS     :=
+LDFLAGS     := -L$(LDIR)
+
+# build flags
+ifeq ($(TARGET_OS),darwin)
+    LDFLAGS += -rpath $(CUDA_PATH)/lib
+    CCFLAGS += -arch $(HOST_ARCH)
+else ifeq ($(HOST_ARCH)-$(TARGET_ARCH)-$(TARGET_OS),x86_64-armv7l-linux)
+    LDFLAGS += --dynamic-linker=/lib/ld-linux-armhf.so.3
+    CCFLAGS += -mfloat-abi=hard
+else ifeq ($(TARGET_OS),android)
+    LDFLAGS += -pie
+    CCFLAGS += -fpie -fpic -fexceptions
+endif
+
+ifneq ($(TARGET_ARCH),$(HOST_ARCH))
+    ifeq ($(TARGET_ARCH)-$(TARGET_OS),armv7l-linux)
+        ifneq ($(TARGET_FS),)
+            GCCVERSIONLTEQ46 := $(shell expr `$(HOST_COMPILER) -dumpversion` \<= 4.6)
+            ifeq ($(GCCVERSIONLTEQ46),1)
+                CCFLAGS += --sysroot=$(TARGET_FS)
+            endif
+            LDFLAGS += --sysroot=$(TARGET_FS)
+            LDFLAGS += -rpath-link=$(TARGET_FS)/lib
+            LDFLAGS += -rpath-link=$(TARGET_FS)/usr/lib
+            LDFLAGS += -rpath-link=$(TARGET_FS)/usr/lib/arm-linux-gnueabihf
+        endif
+    endif
+endif
+
+
+# Debug build flags
+ifeq ($(dbg),1)
+      NVCCFLAGS += -g -G
+      Mode_TYPE := Debug
+else
+      Mode_TYPE := Release
+endif
+
+
+ALL_CCFLAGS :=
+ALL_CCFLAGS += $(NVCCFLAGS)
+ALL_CCFLAGS += $(EXTRA_NVCCFLAGS)
+ALL_CCFLAGS += $(addprefix -Xcompiler ,$(CCFLAGS))
+ALL_CCFLAGS += $(addprefix -Xcompiler ,$(EXTRA_CCFLAGS))
+
+ALL_LDFLAGS :=
+ALL_LDFLAGS += $(ALL_CCFLAGS)
+ALL_LDFLAGS += $(addprefix -Xlinker ,$(LDFLAGS))
+ALL_LDFLAGS += $(addprefix -Xlinker ,$(EXTRA_LDFLAGS))
+
+# Common includes and paths for CUDA
+INCLUDES  := -I../../common/inc
+
+# Common includes for OPENGL
+LIBRARIES := 
+
+################################################################################
+
+SAMPLE_ENABLED := 1
+
+# Gencode arguments
+SMS ?= 20 30 35 37 50 52
+
+ifeq ($(SMS),)
+$(info >>> WARNING - no SM architectures have been specified - waiving sample <<<)
+SAMPLE_ENABLED := 0
+endif
+
+ifeq ($(GENCODE_FLAGS),)
+# Generate SASS code for each SM architecture listed in $(SMS)
+$(foreach sm,$(SMS),$(eval GENCODE_FLAGS += -gencode arch=compute_$(sm),code=sm_$(sm)))
+
+# Generate PTX code from the highest SM architecture in $(SMS) to guarantee forward-compatibility
+HIGHEST_SM := $(lastword $(sort $(SMS)))
+ifneq ($(HIGHEST_SM),)
+GENCODE_FLAGS += -gencode arch=compute_$(HIGHEST_SM),code=compute_$(HIGHEST_SM)
+endif
+endif
+
+ifeq ($(SAMPLE_ENABLED),0)
+EXEC ?= @echo "[@]"
+endif
+
+################################################################################
+
+# Target rules
+help:
+	@echo "************************************************************************"
+	@echo "*  Copyright 2016 University of Sheffield.  All rights reserved.       *"
+	@echo "************************************************************************"
+	@echo "make all -> validate &processes XSL model and generates all .cu files  *" 
+	@echo "                                                                       *"  
+	@echo "           ------------------------------------------------            *"
+	@echo "make XSLTPREP -> Validate and preprocesses the xml model               *"
+	@echo "                                                                       *"
+	@echo "           ------------------------------------------------            *"
+	@echo "make XML_Validate -> To validate the XML file                          *"
+	@echo "run "sudo apt install libxml2-utils" to install xmllint                *"
+	@echo "                                                                       *"
+	@echo "           ------------------------------------------------            *"
+	@echo "make build -> builds executables in either release or debug            *"
+	@echo "                   -Debug_Console                                      *"
+	@echo "                          OR                                           *"
+	@echo "                   -Release_Console                                    *"
+	@echo "                                                                       *"
+	@echo "           ------------------------------------------------            *"
+	@echo "                                                                       *"
+	@echo "make console_mode -> builds executables in console mode                *"
+	@echo "                                                                       *"
+	@echo "make < .. > dbg='arg' -> builds in Release/Debug only                  *"
+	@echo "                                'arg' -> 0 or 1 value                  *"
+	@echo "                                                                       *"
+	@echo "To run executables for console mode, run below command:                *"
+	@echo "make run_console iter='arg'                                            *"
+	@echo "           Note that without the 'arg', it only runs for 1 iteration   *"
+	@echo "           ------------------------------------------------            *"                
+	@echo "Alternatively, run the bash script stored in bin/x64. The iteration    *"
+	@echo "default value in console mode is 10. You can simple change it by       *"
+	@echo "entering a new value while running the ./*.sh file.                    *"
+	@echo "                                                                       *"
+	@echo "           ------------------------------------------------            *"
+	@echo "Note: You can manualy change the location/name of the INPUT_DATA       *"
+	@echo "                                                                       *" 
+	@echo "************************************************************************"
+ 
+build: Console_mode 
+
+Console_mode:  CirclesBruteForce_float_console
+
+check.deps:
+ifeq ($(SAMPLE_ENABLED),0)
+	@echo "Sample will be waived due to the above missing dependencies"
+else
+	@echo "Sample is ready - all dependencies have been met"
+endif
+
+io.o: $(SRC_CUDA)io.cu
+	$(EXEC) $(NVCC) $(INCLUDES) $(ALL_CCFLAGS) $(DEBUG) $(GENCODE_FLAGS) $(FLAMELIB) -o $@ -c $<
+
+simulation.o: $(SRC_CUDA)simulation.cu
+	$(EXEC) $(NVCC) $(INCLUDES) $(ALL_CCFLAGS) $(DEBUG) $(GENCODE_FLAGS) $(FLAMELIB) -o $@ -c $<
+
+main.o: $(SRC_CUDA)main.cu
+	$(EXEC) $(NVCC) $(INCLUDES) $(ALL_CCFLAGS) $(DEBUG) $(GENCODE_FLAGS) $(FLAMELIB) -o $@ -c $<
+
+
+CirclesBruteForce_float_console: BUILD_TYPE=$(Mode_TYPE)_Console
+CirclesBruteForce_float_console: io.o simulation.o  main.o 
+	$(EXEC) $(NVCC) $(ALL_LDFLAGS) $(GENCODE_FLAGS) -o $@ $+ $(LIBRARIES)
+	$(EXEC) mkdir -p $(BIN_DIR)$(BUILD_TYPE)
+	$(EXEC) mv $@ $(BIN_DIR)$(BUILD_TYPE)
+	@echo ./$(BUILD_TYPE)/CirclesBruteForce_float_console ../../examples/CirclesBruteForce_float/$(INPUT_DATA) '$$'{1:-1}> $(BIN_DIR)CirclesBruteForce_float_console.sh
+	chmod +x $(BIN_DIR)CirclesBruteForce_float_console.sh
+
+
+run_console: CirclesBruteForce_float_console
+	cd $(BIN_DIR) && ./CirclesBruteForce_float_console.sh $(iter)
+
+clean:
+	rm -f *.o
+	#rm -rf $(BIN_DIR)CirclesBruteForce_float*.sh
+
+clobber: clean 
+

--- a/examples/HostAgentCreation/iterations/0.xml
+++ b/examples/HostAgentCreation/iterations/0.xml
@@ -1,0 +1,3 @@
+<states>
+	<itno>0</itno>
+</states>

--- a/examples/HostAgentCreation/src/model/XMLModelFile.xml
+++ b/examples/HostAgentCreation/src/model/XMLModelFile.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8"?>
+<gpu:xmodel xmlns:gpu="http://www.dcs.shef.ac.uk/~paul/XMMLGPU"
+        xmlns="http://www.dcs.shef.ac.uk/~paul/XMML">
+  <name>HostAgentCreation</name>
+  <gpu:environment>
+    <gpu:constants>
+       <gpu:variable>
+         <type>unsigned int</type>
+         <name>MAX_LIFESPAN</name>
+       </gpu:variable>
+    </gpu:constants>
+
+    <gpu:functionFiles>
+      <file>functions.c</file>
+    </gpu:functionFiles>
+
+    <gpu:initFunctions>
+      <gpu:initFunction>
+        <gpu:name>initialiseHost</gpu:name>
+      </gpu:initFunction>
+      <gpu:initFunction>
+        <gpu:name>generateAgentInit</gpu:name>
+      </gpu:initFunction>
+    </gpu:initFunctions>
+
+    <gpu:exitFunctions>
+      <gpu:exitFunction>
+        <gpu:name>exitFunction</gpu:name>
+      </gpu:exitFunction>
+    </gpu:exitFunctions>
+
+    <gpu:stepFunctions>
+      <gpu:stepFunction>
+        <gpu:name>generateAgentStep</gpu:name>
+      </gpu:stepFunction>
+    </gpu:stepFunctions>
+
+  </gpu:environment>
+  <xagents>
+    <gpu:xagent>
+      <name>Agent</name>
+      <memory>
+        <gpu:variable>
+          <type>unsigned int</type>
+          <name>time_alive</name>
+        </gpu:variable>
+        <gpu:variable>
+          <type>float</type>
+          <name>example_array</name>
+          <arrayLength>4</arrayLength>
+        </gpu:variable>
+      </memory>
+      <functions>
+        <gpu:function>
+          <name>update</name>
+          <currentState>default</currentState>
+          <nextState>default</nextState>
+          <gpu:reallocate>true</gpu:reallocate>
+          <gpu:RNG>false</gpu:RNG>
+        </gpu:function>
+      </functions>
+      <states>
+        <gpu:state><name>default</name></gpu:state>
+        <initialState>default</initialState>
+      </states>
+      <gpu:type>continuous</gpu:type>
+      <gpu:bufferSize>256</gpu:bufferSize>
+    </gpu:xagent>
+  </xagents>
+  <messages>
+  </messages>
+  <layers>
+    <layer><gpu:layerFunction><name>update</name></gpu:layerFunction></layer>
+  </layers>
+
+
+</gpu:xmodel>
+

--- a/examples/HostAgentCreation/src/model/functions.c
+++ b/examples/HostAgentCreation/src/model/functions.c
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2017 University of Sheffield.
+ * Author: Peter Heywood 
+ * Contact: p.richmond@sheffield.ac.uk (http://www.paulrichmond.staff.shef.ac.uk)
+ *
+ * University of Sheffield retain all intellectual property and 
+ * proprietary rights in and to this software and related documentation. 
+ * Any use, reproduction, disclosure, or distribution of this software 
+ * and related documentation without an express license agreement from
+ * University of Sheffield is strictly prohibited.
+ *
+ * For terms of licence agreement please attached licence or view licence 
+ * on www.flamegpu.com website.
+ * 
+ */
+
+#ifndef _FUNCTIONS_H_
+#define _FUNCTIONS_H_
+
+#include "header.h"
+#include <vector>
+
+// Declare global scope variables for host-based agent creation, so allocation of host data is only performed once.
+xmachine_memory_Agent ** h_agent_AoS;
+const unsigned int h_agent_AoS_MAX = 32;
+
+
+/*
+ * An Init function to initialise environment variables, seed a simple host RNG and pre-allocate an array of structs for host-based agent creation.
+ * AoS allocation is performed here rather than in the relevant step function to avoid the performance penalty of repeated allocations.
+ */
+__FLAME_GPU_INIT_FUNC__ void initialiseHost() {
+	// Initialise host and device constant(s)
+	unsigned int max_lifespan = 16;
+	set_MAX_LIFESPAN(&max_lifespan);
+	printf("Set MAX_LIFESPAN = %u\n", max_lifespan);
+
+	// Seed the host random number generator.
+	srand(0);
+
+	/* 
+	  Allocate and initialise an array of agent structs to a global pointer.
+	  Any number can be specified, however it should be less than the maximum number defined in XMLModelFile.xml
+	  To avoid a per-iteration performance penalty the allocation is performed in an INIT function, and deallocation in an EXIT function
+	*/
+	h_agent_AoS = h_allocate_agent_Agent_array(h_agent_AoS_MAX);
+
+}
+
+/*
+ * An example of how to generate a single new agent from the host.
+ * In this case an INIT function is used.
+ * Memory is allocated and deallocated locally to this method, as it is the only use.
+ * When the h_add_agent_Agent_default() function is called, the data from the struct is immediately copied from the host to device.
+ * If you wish to create more than one agent of the same type and state is will be much more efficient to use the add_agents_ function.
+ */
+__FLAME_GPU_INIT_FUNC__ void generateAgentInit(){
+	printf("Population from initial states XML file: %u\n", get_agent_Agent_default_count());
+	
+	// Allocate a single agent struct on the host.
+	xmachine_memory_Agent * h_agent = h_allocate_agent_Agent();
+
+	// Set values as required for the single agent.
+	h_agent->time_alive = rand() % (*get_MAX_LIFESPAN());
+	for (unsigned int i = 0; i < xmachine_memory_Agent_example_array_LENGTH; i++) {
+		h_agent->example_array[i] = rand() + i;
+	}
+
+	// Copy agent data from the host to the device
+	h_add_agent_Agent_default(h_agent);
+
+	// Clear host memory for single struct. The Utility function also deallocates any agent variable arrays.
+	h_free_agent_Agent(&h_agent);
+	
+	printf("Population after init function: %u\n", get_agent_Agent_default_count());
+}
+
+/*
+ * STEP function to demonstrate the addition of multiple agents from the host.
+ * If it is possible to add new agents to the target agent state on the device, upto 32 agents will be created, with randomised initial data
+ * The AoS is allocated (and deallocate) outside of this method, to avoid performance penalty.
+ * The AoS is converted to a SoA and copied to the device when h_add_agents_Agent_default() is called.
+ */
+__FLAME_GPU_STEP_FUNC__ void generateAgentStep(){
+
+	// Can create upto h_agent_AoS_MAX agents in a single pass (the number allocated for) but the full amount does not have to be created.
+	unsigned int count = 32;
+
+	// It is sensible to check if it is possible to create new agents, and if so how many.
+	unsigned int agent_remaining = xmachine_memory_Agent_MAX - get_agent_Agent_default_count();
+	if (agent_remaining > 0) {
+		if (count > agent_remaining) {
+			count = agent_remaining;
+		}
+		// Populate data as required
+		for (unsigned int i = 0; i < count; i++) {
+			h_agent_AoS[i]->time_alive = rand() % (*get_MAX_LIFESPAN());
+			for (unsigned int j = 0; j < xmachine_memory_Agent_example_array_LENGTH; j++) {
+				h_agent_AoS[i]->example_array[j] = rand() + j;
+			}
+		}
+		// Copy the data to the device
+		h_add_agents_Agent_default(h_agent_AoS, count);
+	}
+
+	printf("Population after step function %u\n", get_agent_Agent_default_count());
+}
+
+/*
+ * EXIT function which frees global scope, allocated memory for the AoS.
+ * The utility function is used to automatically handle agent array variables.
+ */
+__FLAME_GPU_EXIT_FUNC__ void exitFunction(){
+	// Clear host memory for the agent array of structs.
+	h_free_agent_Agent_array(&h_agent_AoS, h_agent_AoS_MAX);
+
+	printf("Population for exit function: %u\n", get_agent_Agent_default_count());
+}
+
+/**
+ * Simple agent function, incrementing the time of life of the agent. 
+ * If the agent has exceeded the maximum life span, it dies.
+ */
+__FLAME_GPU_FUNC__ int update(xmachine_memory_Agent* agent)
+{
+	// Increment time alive
+	agent->time_alive++;
+	/*printf(
+		"%u {%u [%f %f %f %f]}\n", 
+		threadIdx.x + blockDim.x * blockIdx.x, 
+		agent->time_alive, 
+		get_Agent_agent_array_value<float>(agent->example_array, 0), 
+		get_Agent_agent_array_value<float>(agent->example_array, 1), 
+		get_Agent_agent_array_value<float>(agent->example_array, 2), 
+		get_Agent_agent_array_value<float>(agent->example_array, 3)
+	);*/
+	// If agent has been alive long enough, kill them.
+	if (agent->time_alive > MAX_LIFESPAN){
+		return 1;
+	}	
+	return 0;
+}
+
+
+#endif // #ifndef _FUNCTIONS_H_


### PR DESCRIPTION
Allows users to specify the creation of agents on the host, and transfer
to target states on the device.
Utility functions are provided to allocate and deallocate agent structures and arrays of structures, including support for agent variable arrays.
An associated example is included, demonstrating use of the additional functionality.

Additionally, a new `#define` is created for the length of agent variable arrays.

Closes #73 