### PR TITLE
Rc1.5/no initfile

### DIFF
--- a/FLAMEGPU/templates/io.xslt
+++ b/FLAMEGPU/templates/io.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:xmml="http://www.dcs.shef.ac.uk/~paul/XMML"
                 xmlns:gpu="http://www.dcs.shef.ac.uk/~paul/XMMLGPU">
 <xsl:output method="text" version="1.0" encoding="UTF-8" indent="yes" />
@@ -27,7 +27,7 @@
 #include &lt;string.h&gt;
 #include &lt;cmath&gt;
 #include &lt;limits.h&gt;
-	
+
 
 // include header
 #include "header.h"
@@ -46,9 +46,9 @@ void readIntArrayInput(char* buffer, int *array, unsigned int expected_items){
             printf("Error: Agent memory array has too many items, expected %d!\n", expected_items);
             exit(EXIT_FAILURE);
         }
-        
+
         array[i++] = atoi(token);
-        
+
         token = strtok(NULL, s);
     }
     if (i != expected_items){
@@ -68,9 +68,9 @@ void readFloatArrayInput(char* buffer, float *array, unsigned int expected_items
             printf("Error: Agent memory array has too many items, expected %d!\n", expected_items);
             exit(EXIT_FAILURE);
         }
-        
+
         array[i++] = (float)atof(token);
-        
+
         token = strtok(NULL, s);
     }
     if (i != expected_items){
@@ -82,16 +82,16 @@ void readFloatArrayInput(char* buffer, float *array, unsigned int expected_items
 void saveIterationData(char* outputpath, int iteration_number, <xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent/xmml:states/gpu:state">xmachine_memory_<xsl:value-of select="../../xmml:name"/>_list* h_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:name"/>, xmachine_memory_<xsl:value-of select="../../xmml:name"/>_list* d_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:name"/>, int h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_count<xsl:if test="position()!=last()">,</xsl:if></xsl:for-each>)
 {
 	cudaError_t cudaStatus;
-	
+
 	//Device to host memory transfer
 	<xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent/xmml:states/gpu:state">
 	cudaStatus = cudaMemcpy( h_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:name"/>, d_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:name"/>, sizeof(xmachine_memory_<xsl:value-of select="../../xmml:name"/>_list), cudaMemcpyDeviceToHost);
-	if (cudaStatus != cudaSuccess) 
+	if (cudaStatus != cudaSuccess)
 	{
 		fprintf(stderr,"Error Copying <xsl:value-of select="../../xmml:name"/> Agent <xsl:value-of select="xmml:name"/> State Memory from GPU: %s\n", cudaGetErrorString(cudaStatus));
 		exit(cudaStatus);
 	}</xsl:for-each>
-	
+
 	/* Pointer to file */
 	FILE *file;
 	char data[100];
@@ -123,10 +123,10 @@ void saveIterationData(char* outputpath, int iteration_number, <xsl:for-each sel
 		fputs("&lt;/xagent&gt;\n", file);
 	}
 	</xsl:for-each>
-	
+
 
 	fputs("&lt;/states&gt;\n" , file);
-	
+
 	/* Close the file */
 	fclose(file);
 }
@@ -151,27 +151,21 @@ void readInitialStates(char* inputpath, <xsl:for-each select="gpu:xmodel/xmml:xa
 	int in_tag, in_itno, in_name;<xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent/xmml:memory/gpu:variable">
     int in_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>;</xsl:for-each>
 
-	/* for continuous agents: set agent count to zero */<xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent"><xsl:if test="gpu:type='continuous'">	
+	/* for continuous agents: set agent count to zero */<xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent"><xsl:if test="gpu:type='continuous'">
 	*h_xmachine_memory_<xsl:value-of select="xmml:name"/>_count = 0;</xsl:if></xsl:for-each>
-	
+
 	/* Variables for initial state data */<xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent/xmml:memory/gpu:variable"><xsl:choose><xsl:when test="xmml:arrayLength"><xsl:text>
     </xsl:text><xsl:value-of select="xmml:type"/><xsl:text> </xsl:text><xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>[<xsl:value-of select="xmml:arrayLength"/>];</xsl:when><xsl:otherwise><xsl:text>
 	</xsl:text><xsl:value-of select="xmml:type"/><xsl:text> </xsl:text><xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>;</xsl:otherwise></xsl:choose></xsl:for-each>
-	
-	/* Open config file to read-only */
-	if((file = fopen(inputpath, "r"))==NULL)
-	{
-		printf("Error opening initial states\n");
-		exit(EXIT_FAILURE);
-	}
-	
+
+
 	/* Initialise variables */
-    agent_maximum.x = 0;
-    agent_maximum.y = 0;
-    agent_maximum.z = 0;
-    agent_minimum.x = 0;
-    agent_minimum.y = 0;
-    agent_minimum.z = 0;
+  agent_maximum.x = 0;
+  agent_maximum.y = 0;
+  agent_maximum.z = 0;
+  agent_minimum.x = 0;
+  agent_minimum.y = 0;
+  agent_minimum.z = 0;
 	reading = 1;
 	in_tag = 0;
 	in_itno = 0;
@@ -196,19 +190,27 @@ void readInitialStates(char* inputpath, <xsl:for-each select="gpu:xmodel/xmml:xa
     }</xsl:when><xsl:otherwise><xsl:text>
     </xsl:text><xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/> = <xsl:choose><xsl:when test="xmml:defaultValue"><xsl:value-of select="xmml:defaultValue"/></xsl:when><xsl:otherwise>0</xsl:otherwise></xsl:choose>;</xsl:otherwise></xsl:choose></xsl:for-each>
 
+  /* Open config file to read-only */
+  /* If inputfile is empty or not found then we initialise only */
+	if(inputpath == NULL || (file = fopen(inputpath, "r"))==NULL)
+	{
+    printf("Initial states file not specifed or does not exist, parameters are initialised to default values\n");
+    return;
+	}
+
 	/* Read file until end of xml */
     i = 0;
 	while(reading==1)
 	{
 		/* Get the next char from the file */
 		c = (char)fgetc(file);
-		
+
 		/* If the end of a tag */
 		if(c == '&gt;')
 		{
 			/* Place 0 at end of buffer to make chars a string */
 			buffer[i] = 0;
-			
+
 			if(strcmp(buffer, "states") == 0) reading = 1;
 			if(strcmp(buffer, "/states") == 0) reading = 0;
 			if(strcmp(buffer, "itno") == 0) in_itno = 1;
@@ -219,7 +221,7 @@ void readInitialStates(char* inputpath, <xsl:for-each select="gpu:xmodel/xmml:xa
 			{
 				<xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent">
 				<xsl:if test="position()!=1">else </xsl:if>if(strcmp(agentname, "<xsl:value-of select="xmml:name"/>") == 0)
-				{		
+				{
 					if (*h_xmachine_memory_<xsl:value-of select="xmml:name"/>_count > xmachine_memory_<xsl:value-of select="xmml:name"/>_MAX){
 						printf("ERROR: MAX Buffer size (%i) for agent <xsl:value-of select="xmml:name"/> exceeded whilst reading data\n", xmachine_memory_<xsl:value-of select="xmml:name"/>_MAX);
 						// Close the file and stop reading
@@ -228,7 +230,7 @@ void readInitialStates(char* inputpath, <xsl:for-each select="gpu:xmodel/xmml:xa
 					}
                     <xsl:for-each select="xmml:memory/gpu:variable"><xsl:choose><xsl:when test="xmml:arrayLength">
                     for (int k=0;k&lt;<xsl:value-of select="xmml:arrayLength"/>;k++){
-                        h_<xsl:value-of select="../../xmml:name"/>s-><xsl:value-of select="xmml:name"/>[(k*xmachine_memory_<xsl:value-of select="../../xmml:name"/>_MAX)+(*h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count)] = <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>[k];    
+                        h_<xsl:value-of select="../../xmml:name"/>s-><xsl:value-of select="xmml:name"/>[(k*xmachine_memory_<xsl:value-of select="../../xmml:name"/>_MAX)+(*h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count)] = <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>[k];
                     }</xsl:when><xsl:otherwise>
 					h_<xsl:value-of select="../../xmml:name"/>s-><xsl:value-of select="xmml:name"/>[*h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count] = <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>;</xsl:otherwise></xsl:choose>
                     <xsl:if test="xmml:name='x'">//Check maximum x value
@@ -255,15 +257,15 @@ void readInitialStates(char* inputpath, <xsl:for-each select="gpu:xmodel/xmml:xa
                     if(agent_minimum.z &gt; <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>)
                         agent_minimum.z = (float)<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>;
                     </xsl:if></xsl:for-each>
-					(*h_xmachine_memory_<xsl:value-of select="xmml:name"/>_count) ++;	
+					(*h_xmachine_memory_<xsl:value-of select="xmml:name"/>_count) ++;
 				}
 				</xsl:for-each>else
 				{
 					printf("Warning: agent name undefined - '%s'\n", agentname);
 				}
-				
 
-				
+
+
 				/* Reset xagent variables */<xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent/xmml:memory/gpu:variable"><xsl:choose><xsl:when test="xmml:arrayLength">
                 for (i=0;i&lt;<xsl:value-of select="xmml:arrayLength"/>;i++){
                     <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>[i] = <xsl:choose><xsl:when test="xmml:defaultValue"><xsl:value-of select="xmml:defaultValue"/></xsl:when><xsl:otherwise>0</xsl:otherwise></xsl:choose>;
@@ -274,7 +276,7 @@ void readInitialStates(char* inputpath, <xsl:for-each select="gpu:xmodel/xmml:xa
 			<xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent/xmml:memory/gpu:variable">if(strcmp(buffer, "<xsl:value-of select="xmml:name"/>") == 0) in_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/> = 1;
 			if(strcmp(buffer, "/<xsl:value-of select="xmml:name"/>") == 0) in_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/> = 0;
 			</xsl:for-each>
-			
+
 			/* End of tag and reset buffer */
 			in_tag = 0;
 			i = 0;
@@ -286,18 +288,18 @@ void readInitialStates(char* inputpath, <xsl:for-each select="gpu:xmodel/xmml:xa
 			buffer[i] = 0;
 			/* Flag in tag */
 			in_tag = 1;
-			
+
 			if(in_itno) *itno = atoi(buffer);
 			if(in_name) strcpy(agentname, buffer);
 			else
 			{
-				<xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent/xmml:memory/gpu:variable">if(in_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>){ 
+				<xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent/xmml:memory/gpu:variable">if(in_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>){
                     <xsl:choose><xsl:when test="xmml:arrayLength">read<xsl:choose><xsl:when test="xmml:type='int'">Int</xsl:when><xsl:otherwise>Float</xsl:otherwise></xsl:choose>ArrayInput(buffer, <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>, <xsl:value-of select="xmml:arrayLength"/>);    </xsl:when>
                     <xsl:otherwise><xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/> = (<xsl:value-of select="xmml:type"/>) ato<xsl:choose><xsl:when test="xmml:type='int'">i</xsl:when><xsl:otherwise>f</xsl:otherwise></xsl:choose>(buffer);    </xsl:otherwise></xsl:choose>
                 }
 				</xsl:for-each>
 			}
-			
+
 			/* Reset buffer */
 			i = 0;
 		}

--- a/FLAMEGPU/templates/io.xslt
+++ b/FLAMEGPU/templates/io.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
                 xmlns:xmml="http://www.dcs.shef.ac.uk/~paul/XMML"
                 xmlns:gpu="http://www.dcs.shef.ac.uk/~paul/XMMLGPU">
 <xsl:output method="text" version="1.0" encoding="UTF-8" indent="yes" />
@@ -27,7 +27,7 @@
 #include &lt;string.h&gt;
 #include &lt;cmath&gt;
 #include &lt;limits.h&gt;
-
+	
 
 // include header
 #include "header.h"
@@ -46,9 +46,9 @@ void readIntArrayInput(char* buffer, int *array, unsigned int expected_items){
             printf("Error: Agent memory array has too many items, expected %d!\n", expected_items);
             exit(EXIT_FAILURE);
         }
-
+        
         array[i++] = atoi(token);
-
+        
         token = strtok(NULL, s);
     }
     if (i != expected_items){
@@ -68,9 +68,9 @@ void readFloatArrayInput(char* buffer, float *array, unsigned int expected_items
             printf("Error: Agent memory array has too many items, expected %d!\n", expected_items);
             exit(EXIT_FAILURE);
         }
-
+        
         array[i++] = (float)atof(token);
-
+        
         token = strtok(NULL, s);
     }
     if (i != expected_items){
@@ -82,16 +82,16 @@ void readFloatArrayInput(char* buffer, float *array, unsigned int expected_items
 void saveIterationData(char* outputpath, int iteration_number, <xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent/xmml:states/gpu:state">xmachine_memory_<xsl:value-of select="../../xmml:name"/>_list* h_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:name"/>, xmachine_memory_<xsl:value-of select="../../xmml:name"/>_list* d_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:name"/>, int h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_count<xsl:if test="position()!=last()">,</xsl:if></xsl:for-each>)
 {
 	cudaError_t cudaStatus;
-
+	
 	//Device to host memory transfer
 	<xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent/xmml:states/gpu:state">
 	cudaStatus = cudaMemcpy( h_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:name"/>, d_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:name"/>, sizeof(xmachine_memory_<xsl:value-of select="../../xmml:name"/>_list), cudaMemcpyDeviceToHost);
-	if (cudaStatus != cudaSuccess)
+	if (cudaStatus != cudaSuccess) 
 	{
 		fprintf(stderr,"Error Copying <xsl:value-of select="../../xmml:name"/> Agent <xsl:value-of select="xmml:name"/> State Memory from GPU: %s\n", cudaGetErrorString(cudaStatus));
 		exit(cudaStatus);
 	}</xsl:for-each>
-
+	
 	/* Pointer to file */
 	FILE *file;
 	char data[100];
@@ -123,10 +123,10 @@ void saveIterationData(char* outputpath, int iteration_number, <xsl:for-each sel
 		fputs("&lt;/xagent&gt;\n", file);
 	}
 	</xsl:for-each>
-
+	
 
 	fputs("&lt;/states&gt;\n" , file);
-
+	
 	/* Close the file */
 	fclose(file);
 }
@@ -151,21 +151,27 @@ void readInitialStates(char* inputpath, <xsl:for-each select="gpu:xmodel/xmml:xa
 	int in_tag, in_itno, in_name;<xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent/xmml:memory/gpu:variable">
     int in_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>;</xsl:for-each>
 
-	/* for continuous agents: set agent count to zero */<xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent"><xsl:if test="gpu:type='continuous'">
+	/* for continuous agents: set agent count to zero */<xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent"><xsl:if test="gpu:type='continuous'">	
 	*h_xmachine_memory_<xsl:value-of select="xmml:name"/>_count = 0;</xsl:if></xsl:for-each>
-
+	
 	/* Variables for initial state data */<xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent/xmml:memory/gpu:variable"><xsl:choose><xsl:when test="xmml:arrayLength"><xsl:text>
     </xsl:text><xsl:value-of select="xmml:type"/><xsl:text> </xsl:text><xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>[<xsl:value-of select="xmml:arrayLength"/>];</xsl:when><xsl:otherwise><xsl:text>
 	</xsl:text><xsl:value-of select="xmml:type"/><xsl:text> </xsl:text><xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>;</xsl:otherwise></xsl:choose></xsl:for-each>
-
-
+	
+	/* Open config file to read-only */
+	if((file = fopen(inputpath, "r"))==NULL)
+	{
+		printf("Error opening initial states\n");
+		exit(EXIT_FAILURE);
+	}
+	
 	/* Initialise variables */
-  agent_maximum.x = 0;
-  agent_maximum.y = 0;
-  agent_maximum.z = 0;
-  agent_minimum.x = 0;
-  agent_minimum.y = 0;
-  agent_minimum.z = 0;
+    agent_maximum.x = 0;
+    agent_maximum.y = 0;
+    agent_maximum.z = 0;
+    agent_minimum.x = 0;
+    agent_minimum.y = 0;
+    agent_minimum.z = 0;
 	reading = 1;
 	in_tag = 0;
 	in_itno = 0;
@@ -190,27 +196,19 @@ void readInitialStates(char* inputpath, <xsl:for-each select="gpu:xmodel/xmml:xa
     }</xsl:when><xsl:otherwise><xsl:text>
     </xsl:text><xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/> = <xsl:choose><xsl:when test="xmml:defaultValue"><xsl:value-of select="xmml:defaultValue"/></xsl:when><xsl:otherwise>0</xsl:otherwise></xsl:choose>;</xsl:otherwise></xsl:choose></xsl:for-each>
 
-  /* Open config file to read-only */
-  /* If inputfile is empty or not found then we initialise only */
-	if(inputpath == NULL || (file = fopen(inputpath, "r"))==NULL)
-	{
-    printf("Initial states file not specifed or does not exist, parameters are initialised to default values\n");
-    return;
-	}
-
 	/* Read file until end of xml */
     i = 0;
 	while(reading==1)
 	{
 		/* Get the next char from the file */
 		c = (char)fgetc(file);
-
+		
 		/* If the end of a tag */
 		if(c == '&gt;')
 		{
 			/* Place 0 at end of buffer to make chars a string */
 			buffer[i] = 0;
-
+			
 			if(strcmp(buffer, "states") == 0) reading = 1;
 			if(strcmp(buffer, "/states") == 0) reading = 0;
 			if(strcmp(buffer, "itno") == 0) in_itno = 1;
@@ -221,7 +219,7 @@ void readInitialStates(char* inputpath, <xsl:for-each select="gpu:xmodel/xmml:xa
 			{
 				<xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent">
 				<xsl:if test="position()!=1">else </xsl:if>if(strcmp(agentname, "<xsl:value-of select="xmml:name"/>") == 0)
-				{
+				{		
 					if (*h_xmachine_memory_<xsl:value-of select="xmml:name"/>_count > xmachine_memory_<xsl:value-of select="xmml:name"/>_MAX){
 						printf("ERROR: MAX Buffer size (%i) for agent <xsl:value-of select="xmml:name"/> exceeded whilst reading data\n", xmachine_memory_<xsl:value-of select="xmml:name"/>_MAX);
 						// Close the file and stop reading
@@ -230,7 +228,7 @@ void readInitialStates(char* inputpath, <xsl:for-each select="gpu:xmodel/xmml:xa
 					}
                     <xsl:for-each select="xmml:memory/gpu:variable"><xsl:choose><xsl:when test="xmml:arrayLength">
                     for (int k=0;k&lt;<xsl:value-of select="xmml:arrayLength"/>;k++){
-                        h_<xsl:value-of select="../../xmml:name"/>s-><xsl:value-of select="xmml:name"/>[(k*xmachine_memory_<xsl:value-of select="../../xmml:name"/>_MAX)+(*h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count)] = <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>[k];
+                        h_<xsl:value-of select="../../xmml:name"/>s-><xsl:value-of select="xmml:name"/>[(k*xmachine_memory_<xsl:value-of select="../../xmml:name"/>_MAX)+(*h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count)] = <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>[k];    
                     }</xsl:when><xsl:otherwise>
 					h_<xsl:value-of select="../../xmml:name"/>s-><xsl:value-of select="xmml:name"/>[*h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count] = <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>;</xsl:otherwise></xsl:choose>
                     <xsl:if test="xmml:name='x'">//Check maximum x value
@@ -257,15 +255,15 @@ void readInitialStates(char* inputpath, <xsl:for-each select="gpu:xmodel/xmml:xa
                     if(agent_minimum.z &gt; <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>)
                         agent_minimum.z = (float)<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>;
                     </xsl:if></xsl:for-each>
-					(*h_xmachine_memory_<xsl:value-of select="xmml:name"/>_count) ++;
+					(*h_xmachine_memory_<xsl:value-of select="xmml:name"/>_count) ++;	
 				}
 				</xsl:for-each>else
 				{
 					printf("Warning: agent name undefined - '%s'\n", agentname);
 				}
+				
 
-
-
+				
 				/* Reset xagent variables */<xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent/xmml:memory/gpu:variable"><xsl:choose><xsl:when test="xmml:arrayLength">
                 for (i=0;i&lt;<xsl:value-of select="xmml:arrayLength"/>;i++){
                     <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>[i] = <xsl:choose><xsl:when test="xmml:defaultValue"><xsl:value-of select="xmml:defaultValue"/></xsl:when><xsl:otherwise>0</xsl:otherwise></xsl:choose>;
@@ -276,7 +274,7 @@ void readInitialStates(char* inputpath, <xsl:for-each select="gpu:xmodel/xmml:xa
 			<xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent/xmml:memory/gpu:variable">if(strcmp(buffer, "<xsl:value-of select="xmml:name"/>") == 0) in_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/> = 1;
 			if(strcmp(buffer, "/<xsl:value-of select="xmml:name"/>") == 0) in_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/> = 0;
 			</xsl:for-each>
-
+			
 			/* End of tag and reset buffer */
 			in_tag = 0;
 			i = 0;
@@ -288,18 +286,18 @@ void readInitialStates(char* inputpath, <xsl:for-each select="gpu:xmodel/xmml:xa
 			buffer[i] = 0;
 			/* Flag in tag */
 			in_tag = 1;
-
+			
 			if(in_itno) *itno = atoi(buffer);
 			if(in_name) strcpy(agentname, buffer);
 			else
 			{
-				<xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent/xmml:memory/gpu:variable">if(in_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>){
+				<xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent/xmml:memory/gpu:variable">if(in_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>){ 
                     <xsl:choose><xsl:when test="xmml:arrayLength">read<xsl:choose><xsl:when test="xmml:type='int'">Int</xsl:when><xsl:otherwise>Float</xsl:otherwise></xsl:choose>ArrayInput(buffer, <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>, <xsl:value-of select="xmml:arrayLength"/>);    </xsl:when>
                     <xsl:otherwise><xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/> = (<xsl:value-of select="xmml:type"/>) ato<xsl:choose><xsl:when test="xmml:type='int'">i</xsl:when><xsl:otherwise>f</xsl:otherwise></xsl:choose>(buffer);    </xsl:otherwise></xsl:choose>
                 }
 				</xsl:for-each>
 			}
-
+			
 			/* Reset buffer */
 			i = 0;
 		}

--- a/FLAMEGPU/templates/main.xslt
+++ b/FLAMEGPU/templates/main.xslt
@@ -102,11 +102,11 @@ void initCUDA(int argc, char** argv){
 	cudaStatus = cudaGetDeviceCount(&amp;device_count);
 
 	if (cudaStatus != cudaSuccess) {
-		fprintf(stderr, "Error finding CUDA devices!  Do you have a CUDA-capable GPU installed?\n");
+		fprintf(stderr, "Error finding CUDA devices!  Do you have a CUDA-capable GPU installed?");
 		exit(EXIT_FAILURE);
 	}
 	if (device_count == 0){
-		fprintf(stderr, "Error no CUDA devices found!\n");
+		fprintf(stderr, "Error no CUDA devices found!");
 		exit(EXIT_FAILURE);
 	}
 
@@ -121,14 +121,14 @@ void initCUDA(int argc, char** argv){
 #endif
 
 	if (device >= device_count){
-		fprintf(stderr, "Error selecting CUDA device! Device id '%d' is not found?\n", device);
+		fprintf(stderr, "Error selecting CUDA device! Device id '%d' is not found?", device);
 		exit(EXIT_FAILURE);
 	}
 
 	// Select device
 	cudaStatus = cudaSetDevice(device);
 	if (cudaStatus != cudaSuccess) {
-		fprintf(stderr, "Error setting CUDA device!\n");
+		fprintf(stderr, "Error setting CUDA device!");
 		exit(EXIT_FAILURE);
 	}
 }
@@ -213,7 +213,7 @@ int main( int argc, char** argv)
 	cleanup();
 	cudaStatus = cudaDeviceReset();
 	if (cudaStatus != cudaSuccess) {
-		fprintf(stderr, "Error resetting the device!\n");
+		fprintf(stderr, "Error resetting the device!");
 		return EXIT_FAILURE;
 	}
 	return EXIT_SUCCESS;

--- a/FLAMEGPU/templates/main.xslt
+++ b/FLAMEGPU/templates/main.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
                 xmlns:xmml="http://www.dcs.shef.ac.uk/~paul/XMML"
                 xmlns:gpu="http://www.dcs.shef.ac.uk/~paul/XMMLGPU">
 <xsl:output method="text" version="1.0" encoding="UTF-8" indent="yes" />
@@ -137,7 +137,7 @@ void initCUDA(int argc, char** argv){
 /**
  * Program main (Handles arguments)
  */
-int main( int argc, char** argv)
+int main( int argc, char** argv) 
 {
 	cudaError_t cudaStatus;
 	//check usage mode
@@ -158,20 +158,19 @@ int main( int argc, char** argv)
 	//initialise the simulation
 	initialise(inputfile);
 
-  printf("Initialise ok");
-
+    
 #ifdef VISUALISATION
 	runVisualisation();
 	exit(EXIT_SUCCESS);
-#else
+#else	
 	//Benchmark simulation
 	cudaEvent_t start, stop;
 	float milliseconds = 0;
-
+	
 	//create timing events
 	cudaEventCreate(&amp;start);
 	cudaEventCreate(&amp;stop);
-
+	
 	//Get the number of iterations
 	int iterations = atoi(argv[2]);
 	if (iterations == 0)
@@ -179,7 +178,7 @@ int main( int argc, char** argv)
 		printf("Second argument must be an integer (Number of Iterations)\n");
 		exit(EXIT_FAILURE);
 	}
-
+  
 	//start timing
 	cudaEventRecord(start);
 
@@ -196,7 +195,7 @@ int main( int argc, char** argv)
 				//<xsl:value-of select="xmml:name"/> state <xsl:value-of select="../../xmml:name"/> agents
 				get_host_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_agents(), get_device_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_agents(), get_agent_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_count()<xsl:choose><xsl:when test="position()=last()">);</xsl:when><xsl:otherwise>,</xsl:otherwise></xsl:choose>
 				</xsl:for-each>
-
+			
 				printf("Iteration %i Saved to XML\n", i+1);
 		}
 

--- a/FLAMEGPU/templates/main.xslt
+++ b/FLAMEGPU/templates/main.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:xmml="http://www.dcs.shef.ac.uk/~paul/XMML"
                 xmlns:gpu="http://www.dcs.shef.ac.uk/~paul/XMMLGPU">
 <xsl:output method="text" version="1.0" encoding="UTF-8" indent="yes" />
@@ -137,7 +137,7 @@ void initCUDA(int argc, char** argv){
 /**
  * Program main (Handles arguments)
  */
-int main( int argc, char** argv) 
+int main( int argc, char** argv)
 {
 	cudaError_t cudaStatus;
 	//check usage mode
@@ -158,19 +158,20 @@ int main( int argc, char** argv)
 	//initialise the simulation
 	initialise(inputfile);
 
-    
+  printf("Initialise ok");
+
 #ifdef VISUALISATION
 	runVisualisation();
 	exit(EXIT_SUCCESS);
-#else	
+#else
 	//Benchmark simulation
 	cudaEvent_t start, stop;
 	float milliseconds = 0;
-	
+
 	//create timing events
 	cudaEventCreate(&amp;start);
 	cudaEventCreate(&amp;stop);
-	
+
 	//Get the number of iterations
 	int iterations = atoi(argv[2]);
 	if (iterations == 0)
@@ -178,7 +179,7 @@ int main( int argc, char** argv)
 		printf("Second argument must be an integer (Number of Iterations)\n");
 		exit(EXIT_FAILURE);
 	}
-  
+
 	//start timing
 	cudaEventRecord(start);
 
@@ -195,7 +196,7 @@ int main( int argc, char** argv)
 				//<xsl:value-of select="xmml:name"/> state <xsl:value-of select="../../xmml:name"/> agents
 				get_host_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_agents(), get_device_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_agents(), get_agent_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_count()<xsl:choose><xsl:when test="position()=last()">);</xsl:when><xsl:otherwise>,</xsl:otherwise></xsl:choose>
 				</xsl:for-each>
-			
+
 				printf("Iteration %i Saved to XML\n", i+1);
 		}
 

--- a/FLAMEGPU/templates/simulation.xslt
+++ b/FLAMEGPU/templates/simulation.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
                 xmlns:xmml="http://www.dcs.shef.ac.uk/~paul/XMML"
                 xmlns:gpu="http://www.dcs.shef.ac.uk/~paul/XMMLGPU">
 <xsl:output method="text" version="1.0" encoding="UTF-8" indent="yes" />
@@ -7,18 +7,18 @@
 /*
  * FLAME GPU v 1.4.0 for CUDA 6
  * Copyright 2015 University of Sheffield.
- * Author: Dr Paul Richmond
+ * Author: Dr Paul Richmond 
  * Contact: p.richmond@sheffield.ac.uk (http://www.paulrichmond.staff.shef.ac.uk)
  *
- * University of Sheffield retain all intellectual property and
- * proprietary rights in and to this software and related documentation.
- * Any use, reproduction, disclosure, or distribution of this software
+ * University of Sheffield retain all intellectual property and 
+ * proprietary rights in and to this software and related documentation. 
+ * Any use, reproduction, disclosure, or distribution of this software 
  * and related documentation without an express license agreement from
  * University of Sheffield is strictly prohibited.
  *
- * For terms of licence agreement please attached licence or view licence
+ * For terms of licence agreement please attached licence or view licence 
  * on www.flamegpu.com website.
- *
+ * 
  */
 
 //Disable internal thrust warnings about conversions
@@ -57,7 +57,7 @@
 #define gpuErrchk(ans) { gpuAssert((ans), __FILE__, __LINE__); }
 inline void gpuAssert(cudaError_t code, const char *file, int line, bool abort=true)
 {
-   if (code != cudaSuccess)
+   if (code != cudaSuccess) 
    {
       fprintf(stderr,"GPUassert: %s %s %d\n", cudaGetErrorString(code), file, line);
       if (abort) exit(code);
@@ -72,7 +72,7 @@ inline void gpuLaunchAssert(const char *file, int line, bool abort=true)
 #ifdef _DEBUG
 	gpuAssert( cudaDeviceSynchronize(), file, line );
 #endif
-
+   
 }
 
 /* SM padding and offset variables */
@@ -93,7 +93,7 @@ uint * d_xmachine_memory_<xsl:value-of select="xmml:name"/>_values;  /**&lt; Age
 /* <xsl:value-of select="../../xmml:name"/> state variables */
 xmachine_memory_<xsl:value-of select="../../xmml:name"/>_list* h_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:name"/>;      /**&lt; Pointer to agent list (population) on host*/
 xmachine_memory_<xsl:value-of select="../../xmml:name"/>_list* d_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:name"/>;      /**&lt; Pointer to agent list (population) on the device*/
-int h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_count;   /**&lt; Agent population size counter */
+int h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_count;   /**&lt; Agent population size counter */ 
 </xsl:for-each>
 </xsl:for-each>
 
@@ -129,7 +129,7 @@ int h_tex_xmachine_message_<xsl:value-of select="xmml:name"/>_pbm_start_offset;
 int h_tex_xmachine_message_<xsl:value-of select="xmml:name"/>_pbm_end_or_count_offset;
 </xsl:if></xsl:if>
 </xsl:for-each>
-
+  
 /* CUDA Streams for function layers */<xsl:for-each select="gpu:xmodel/xmml:layers/xmml:layer">
 <xsl:sort select="count(gpu:layerFunction)" order="descending"/>
 <xsl:if test="position() =1"> <!-- Get the layer with most functions -->
@@ -167,7 +167,7 @@ int scan_last_included;      /**&lt; Indicates if last sum value is included in 
  */
 void <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>(cudaStream_t &amp;stream);
 </xsl:for-each>
-
+  
 void setPaddingAndOffset()
 {
 	cudaDeviceProp deviceProp;
@@ -179,7 +179,7 @@ void setPaddingAndOffset()
 		printf("Error: There is no device supporting CUDA.\n");
 		exit(EXIT_FAILURE);
 	}
-
+    
     //check if double is used and supported
 #ifdef _DOUBLE_SUPPORT_REQUIRED_
 	printf("Simulation requires full precision double values\n");
@@ -187,7 +187,7 @@ void setPaddingAndOffset()
 		printf("Error: Hardware does not support full precision double values!\n");
 		exit(EXIT_FAILURE);
 	}
-
+    
 #endif
 
 	//check 32 or 64bit
@@ -203,10 +203,10 @@ void setPaddingAndOffset()
 
 	SM_START = 0;
 	PADDING = 0;
-
+  
 	//copy padding and offset to GPU
 	gpuErrchk(cudaMemcpyToSymbol( d_SM_START, &amp;SM_START, sizeof(int)));
-	gpuErrchk(cudaMemcpyToSymbol( d_PADDING, &amp;PADDING, sizeof(int)));
+	gpuErrchk(cudaMemcpyToSymbol( d_PADDING, &amp;PADDING, sizeof(int)));     
 }
 
 int is_sqr_pow2(int x){
@@ -216,14 +216,14 @@ int is_sqr_pow2(int x){
 
 int lowest_sqr_pow2(int x){
 	int l;
-
+	
 	//escape early if x is square power of 2
 	if (is_sqr_pow2(x))
 		return x;
-
-	//lower bound
+	
+	//lower bound		
 	l = (int)pow(4, floor(log(x)/log(4)));
-
+	
 	return l;
 }
 
@@ -243,10 +243,10 @@ void initialise(char * inputfile){
 
 	//set the padding and offset values depending on architecture and OS
 	setPaddingAndOffset();
-
+  
 
 	printf("Allocating Host and Device memory\n");
-
+  
 	/* Agent memory allocation (CPU) */<xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent">
 	int xmachine_<xsl:value-of select="xmml:name"/>_SoA_size = sizeof(xmachine_memory_<xsl:value-of select="xmml:name"/>_list);<xsl:for-each select="xmml:states/gpu:state">
 	h_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:name"/> = (xmachine_memory_<xsl:value-of select="../../xmml:name"/>_list*)malloc(xmachine_<xsl:value-of select="../../xmml:name"/>_SoA_size);</xsl:for-each></xsl:for-each>
@@ -259,11 +259,11 @@ void initialise(char * inputfile){
 	<xsl:variable name="xagent_output" select="xmml:xagentName"/><xsl:variable name="xagent_buffer" select="../../../../gpu:bufferSize"/><xsl:if test="../../../../../gpu:xagent[xmml:name=$xagent_output]/gpu:bufferSize&lt;$xagent_buffer">
 	printf("ERROR: <xsl:value-of select="$xagent_output"/> agent buffer is too small to be used for output by <xsl:value-of select="../../../../xmml:name"/> agent in <xsl:value-of select="../../xmml:name"/> function!\n");
 	exit(EXIT_FAILURE);
-	</xsl:if>
+	</xsl:if>    
 	</xsl:for-each>
-
+    
 	<xsl:for-each select="gpu:xmodel/xmml:messages/gpu:message"><xsl:if test="gpu:partitioningDiscrete">
-
+	
 	/* Set discrete <xsl:value-of select="xmml:name"/> message variables (range, width)*/
 	h_message_<xsl:value-of select="xmml:name"/>_range = <xsl:value-of select="gpu:partitioningDiscrete/gpu:radius"/>; //from xml
 	h_message_<xsl:value-of select="xmml:name"/>_width = (int)floor(sqrt((float)xmachine_message_<xsl:value-of select="xmml:name"/>_MAX));
@@ -272,24 +272,24 @@ void initialise(char * inputfile){
 		printf("ERROR: <xsl:value-of select="xmml:name"/> message max must be a square power of 2 for a 2D discrete message grid!\n");
 		exit(EXIT_FAILURE);
 	}
-	gpuErrchk(cudaMemcpyToSymbol( d_message_<xsl:value-of select="xmml:name"/>_range, &amp;h_message_<xsl:value-of select="xmml:name"/>_range, sizeof(int)));
+	gpuErrchk(cudaMemcpyToSymbol( d_message_<xsl:value-of select="xmml:name"/>_range, &amp;h_message_<xsl:value-of select="xmml:name"/>_range, sizeof(int)));	
 	gpuErrchk(cudaMemcpyToSymbol( d_message_<xsl:value-of select="xmml:name"/>_width, &amp;h_message_<xsl:value-of select="xmml:name"/>_width, sizeof(int)));
 	</xsl:if><xsl:if test="gpu:partitioningSpatial">
-
+			
 	/* Set spatial partitioning <xsl:value-of select="xmml:name"/> message variables (min_bounds, max_bounds)*/
 	h_message_<xsl:value-of select="xmml:name"/>_radius = (float)<xsl:value-of select="gpu:partitioningSpatial/gpu:radius"/>;
-	gpuErrchk(cudaMemcpyToSymbol( d_message_<xsl:value-of select="xmml:name"/>_radius, &amp;h_message_<xsl:value-of select="xmml:name"/>_radius, sizeof(float)));
+	gpuErrchk(cudaMemcpyToSymbol( d_message_<xsl:value-of select="xmml:name"/>_radius, &amp;h_message_<xsl:value-of select="xmml:name"/>_radius, sizeof(float)));	
 	    h_message_<xsl:value-of select="xmml:name"/>_min_bounds = glm::vec3((float)<xsl:value-of select="gpu:partitioningSpatial/gpu:xmin"/>, (float)<xsl:value-of select="gpu:partitioningSpatial/gpu:ymin"/>, (float)<xsl:value-of select="gpu:partitioningSpatial/gpu:zmin"/>);
-	gpuErrchk(cudaMemcpyToSymbol( d_message_<xsl:value-of select="xmml:name"/>_min_bounds, &amp;h_message_<xsl:value-of select="xmml:name"/>_min_bounds, sizeof(glm::vec3)));
+	gpuErrchk(cudaMemcpyToSymbol( d_message_<xsl:value-of select="xmml:name"/>_min_bounds, &amp;h_message_<xsl:value-of select="xmml:name"/>_min_bounds, sizeof(glm::vec3)));	
 	h_message_<xsl:value-of select="xmml:name"/>_max_bounds = glm::vec3((float)<xsl:value-of select="gpu:partitioningSpatial/gpu:xmax"/>, (float)<xsl:value-of select="gpu:partitioningSpatial/gpu:ymax"/>, (float)<xsl:value-of select="gpu:partitioningSpatial/gpu:zmax"/>);
-	gpuErrchk(cudaMemcpyToSymbol( d_message_<xsl:value-of select="xmml:name"/>_max_bounds, &amp;h_message_<xsl:value-of select="xmml:name"/>_max_bounds, sizeof(glm::vec3)));
+	gpuErrchk(cudaMemcpyToSymbol( d_message_<xsl:value-of select="xmml:name"/>_max_bounds, &amp;h_message_<xsl:value-of select="xmml:name"/>_max_bounds, sizeof(glm::vec3)));	
 	h_message_<xsl:value-of select="xmml:name"/>_partitionDim.x = (int)ceil((h_message_<xsl:value-of select="xmml:name"/>_max_bounds.x - h_message_<xsl:value-of select="xmml:name"/>_min_bounds.x)/h_message_<xsl:value-of select="xmml:name"/>_radius);
 	h_message_<xsl:value-of select="xmml:name"/>_partitionDim.y = (int)ceil((h_message_<xsl:value-of select="xmml:name"/>_max_bounds.y - h_message_<xsl:value-of select="xmml:name"/>_min_bounds.y)/h_message_<xsl:value-of select="xmml:name"/>_radius);
 	h_message_<xsl:value-of select="xmml:name"/>_partitionDim.z = (int)ceil((h_message_<xsl:value-of select="xmml:name"/>_max_bounds.z - h_message_<xsl:value-of select="xmml:name"/>_min_bounds.z)/h_message_<xsl:value-of select="xmml:name"/>_radius);
-	gpuErrchk(cudaMemcpyToSymbol( d_message_<xsl:value-of select="xmml:name"/>_partitionDim, &amp;h_message_<xsl:value-of select="xmml:name"/>_partitionDim, sizeof(glm::ivec3)));
+	gpuErrchk(cudaMemcpyToSymbol( d_message_<xsl:value-of select="xmml:name"/>_partitionDim, &amp;h_message_<xsl:value-of select="xmml:name"/>_partitionDim, sizeof(glm::ivec3)));	
 	</xsl:if></xsl:for-each>
-
-
+	
+	
 	<xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent"><xsl:if test="gpu:type='discrete'">
 	/* Check that population size is a square power of 2*/
 	if (!is_sqr_pow2(xmachine_memory_<xsl:value-of select="xmml:name"/>_MAX)){
@@ -301,7 +301,7 @@ void initialise(char * inputfile){
 
 	//read initial states
 	readInitialStates(inputfile, <xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent">h_<xsl:value-of select="xmml:name"/>s_<xsl:value-of select="xmml:states/xmml:initialState"/>, &amp;h_xmachine_memory_<xsl:value-of select="xmml:name"/>_<xsl:value-of select="xmml:states/xmml:initialState"/>_count<xsl:if test="position()!=last()">, </xsl:if></xsl:for-each>);
-
+	
 	<xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent">
 	/* <xsl:value-of select="xmml:name"/> Agent memory allocation (GPU) */
 	gpuErrchk( cudaMalloc( (void**) &amp;d_<xsl:value-of select="xmml:name"/>s, xmachine_<xsl:value-of select="xmml:name"/>_SoA_size));
@@ -330,7 +330,7 @@ void initialise(char * inputfile){
 	gpuErrchk( cudaMalloc( (void**) &amp;d_xmachine_message_<xsl:value-of select="xmml:name"/>_keys, xmachine_message_<xsl:value-of select="xmml:name"/>_MAX* sizeof(uint)));
 	gpuErrchk( cudaMalloc( (void**) &amp;d_xmachine_message_<xsl:value-of select="xmml:name"/>_values, xmachine_message_<xsl:value-of select="xmml:name"/>_MAX* sizeof(uint)));
 #endif</xsl:if><xsl:text>
-	</xsl:text></xsl:for-each>
+	</xsl:text></xsl:for-each>	
 
 	/*Set global condition counts*/<xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent/xmml:functions/gpu:function/gpu:condition">
 	h_<xsl:value-of select="../xmml:name"/>_condition_false_count = 0;
@@ -387,7 +387,7 @@ void initialise(char * inputfile){
 	printf("Instrumentation: <xsl:value-of select="gpu:name"/> = %f (ms)\n", instrument_milliseconds);
 #endif
 	</xsl:for-each>
-
+  
   /* Init CUDA Streams for function layers */
   <xsl:for-each select="gpu:xmodel/xmml:layers/xmml:layer">
   <xsl:sort select="count(gpu:layerFunction)" order="descending"/>
@@ -403,7 +403,7 @@ void initialise(char * inputfile){
 		printf("Init agent_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_count: %u\n",get_agent_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_count());
 	</xsl:for-each>
 #endif
-}
+} 
 
 <xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent"><xsl:if test="gpu:type='continuous'"> <xsl:for-each select="xmml:states/gpu:state">
 void sort_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:name"/>(void (*generate_key_value_pairs)(unsigned int* keys, unsigned int* values, xmachine_memory_<xsl:value-of select="../../xmml:name"/>_list* agents))
@@ -413,8 +413,8 @@ void sort_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:n
 	int gridSize;
 
 	//generate sort keys
-	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, generate_key_value_pairs, no_sm, h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_count);
-	gridSize = (h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_count + blockSize - 1) / blockSize;    // Round up according to array size
+	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, generate_key_value_pairs, no_sm, h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_count); 
+	gridSize = (h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_count + blockSize - 1) / blockSize;    // Round up according to array size 
 	generate_key_value_pairs&lt;&lt;&lt;gridSize, blockSize&gt;&gt;&gt;(d_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_keys, d_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_values, d_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:name"/>);
 	gpuErrchkLaunch();
 
@@ -423,15 +423,15 @@ void sort_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:n
 	gpuErrchkLaunch();
 
 	//reorder agents
-	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, reorder_<xsl:value-of select="../../xmml:name"/>_agents, no_sm, h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_count);
-	gridSize = (h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_count + blockSize - 1) / blockSize;    // Round up according to array size
+	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, reorder_<xsl:value-of select="../../xmml:name"/>_agents, no_sm, h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_count); 
+	gridSize = (h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_count + blockSize - 1) / blockSize;    // Round up according to array size 
 	reorder_<xsl:value-of select="../../xmml:name"/>_agents&lt;&lt;&lt;gridSize, blockSize&gt;&gt;&gt;(d_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_values, d_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:name"/>, d_<xsl:value-of select="../../xmml:name"/>s_swap);
 	gpuErrchkLaunch();
 
 	//swap
 	xmachine_memory_<xsl:value-of select="../../xmml:name"/>_list* d_<xsl:value-of select="../../xmml:name"/>s_temp = d_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:name"/>;
 	d_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:name"/> = d_<xsl:value-of select="../../xmml:name"/>s_swap;
-	d_<xsl:value-of select="../../xmml:name"/>s_swap = d_<xsl:value-of select="../../xmml:name"/>s_temp;
+	d_<xsl:value-of select="../../xmml:name"/>s_swap = d_<xsl:value-of select="../../xmml:name"/>s_temp;	
 }
 </xsl:for-each></xsl:if></xsl:for-each>
 
@@ -444,7 +444,7 @@ void cleanup(){
 #endif
 
 	<xsl:value-of select="gpu:name"/>();
-
+	
 #if defined(INSTRUMENT_EXIT_FUNCTIONS) &amp;&amp; INSTRUMENT_EXIT_FUNCTIONS
 	cudaEventRecord(instrument_stop);
 	cudaEventSynchronize(instrument_stop);
@@ -480,7 +480,7 @@ void cleanup(){
 	gpuErrchk(cudaFree(d_xmachine_message_<xsl:value-of select="xmml:name"/>_values));
 #endif</xsl:if><xsl:text>
 	</xsl:text></xsl:for-each>
-
+  
   /* CUDA Streams for function layers */
   <xsl:for-each select="gpu:xmodel/xmml:layers/xmml:layer">
   <xsl:sort select="count(gpu:layerFunction)" order="descending"/>
@@ -530,7 +530,7 @@ void singleIteration(){
 #endif
 	</xsl:for-each></xsl:for-each>cudaDeviceSynchronize();
   </xsl:for-each>
-
+    
     /* Call all step functions */
 	<xsl:for-each select="gpu:xmodel/gpu:environment/gpu:stepFunctions/gpu:stepFunction">
 #if defined(INSTRUMENT_STEP_FUNCTIONS) &amp;&amp; INSTRUMENT_STEP_FUNCTIONS
@@ -596,7 +596,7 @@ const <xsl:value-of select="xmml:type"/>* get_<xsl:value-of select="xmml:name"/>
 
 /* Agent data access functions*/
 <xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent">
-
+    
 int get_agent_<xsl:value-of select="xmml:name"/>_MAX_count(){
     return xmachine_memory_<xsl:value-of select="xmml:name"/>_MAX;
 }
@@ -605,7 +605,7 @@ int get_agent_<xsl:value-of select="xmml:name"/>_MAX_count(){
 int get_agent_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_count(){
 	<xsl:if test="../../gpu:type='continuous'">//continuous agent
 	return h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_count;
-	</xsl:if><xsl:if test="../../gpu:type='discrete'">//discrete agent
+	</xsl:if><xsl:if test="../../gpu:type='discrete'">//discrete agent 
 	return xmachine_memory_<xsl:value-of select="../../xmml:name"/>_MAX;</xsl:if>
 }
 
@@ -657,7 +657,7 @@ int get_<xsl:value-of select="xmml:name"/>_population_width(){
 /* Agent functions */
 
 <xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent/xmml:functions/gpu:function">
-
+	
 /* Shared memory size calculator for agent function */
 int <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_sm_size(int blockSize){
 	int sm_size;
@@ -703,13 +703,15 @@ void <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>
 	dim3 g; //grid for agent func
 	dim3 b; //block for agent func
 
-
+	
 	//CHECK THE CURRENT STATE LIST COUNT IS NOT EQUAL TO 0
+	<xsl:if test="../../gpu:type='continuous'">
 	if (h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:currentState"/>_count == 0)
 	{
 		return;
 	}
-
+	</xsl:if>
+	
 	//SET SM size to 0 and save state list size for occupancy calculations
 	sm_size = SM_START;
 	state_list_size = h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:currentState"/>_count;
@@ -718,7 +720,7 @@ void <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>
 	<xsl:for-each select="xmml:xagentOutputs/gpu:xagentOutput">
 	<xsl:variable name="xagent_output" select="xmml:xagentName"/><xsl:if test="../../../../../gpu:xagent[xmml:name=$xagent_output]/gpu:type='continuous'">
 	//FOR <xsl:value-of select="xmml:xagentName"/> AGENT OUTPUT, RESET THE AGENT NEW LIST SCAN INPUT
-	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, reset_<xsl:value-of select="xmml:xagentName"/>_scan_input, no_sm, state_list_size);
+	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, reset_<xsl:value-of select="xmml:xagentName"/>_scan_input, no_sm, state_list_size); 
 	gridSize = (state_list_size + blockSize - 1) / blockSize;
 	reset_<xsl:value-of select="xmml:xagentName"/>_scan_input&lt;&lt;&lt;gridSize, blockSize, 0, stream&gt;&gt;&gt;(d_<xsl:value-of select="xmml:xagentName"/>s_new);
 	gpuErrchkLaunch();
@@ -727,14 +729,14 @@ void <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>
 	//******************************** AGENT FUNCTION CONDITION *********************
 	<xsl:choose>
 	<xsl:when test="xmml:condition"><xsl:if test="../../gpu:type='continuous'">//CONTINUOUS AGENT FUNCTION AND THERE IS A FUNCTION CONDITION
-
+  	
 	//COPY CURRENT STATE COUNT TO WORKING COUNT (host and device)
 	h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count = h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:currentState"/>_count;
-	gpuErrchk( cudaMemcpyToSymbol( d_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count, &amp;h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count, sizeof(int)));
-
+	gpuErrchk( cudaMemcpyToSymbol( d_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count, &amp;h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count, sizeof(int)));	
+	
 	//RESET SCAN INPUTS
 	//reset scan input for currentState
-	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, reset_<xsl:value-of select="../../xmml:name"/>_scan_input, no_sm, state_list_size);
+	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, reset_<xsl:value-of select="../../xmml:name"/>_scan_input, no_sm, state_list_size); 
 	gridSize = (state_list_size + blockSize - 1) / blockSize;
 	reset_<xsl:value-of select="../../xmml:name"/>_scan_input&lt;&lt;&lt;gridSize, blockSize, 0, stream&gt;&gt;&gt;(d_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:currentState"/>);
 	gpuErrchkLaunch();
@@ -743,15 +745,15 @@ void <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>
 	gpuErrchkLaunch();
 
 	//APPLY FUNCTION FILTER
-	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, <xsl:value-of select="xmml:name"/>_function_filter, no_sm, state_list_size);
+	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, <xsl:value-of select="xmml:name"/>_function_filter, no_sm, state_list_size); 
 	gridSize = (state_list_size + blockSize - 1) / blockSize;
 	<xsl:value-of select="xmml:name"/>_function_filter&lt;&lt;&lt;gridSize, blockSize, 0, stream&gt;&gt;&gt;(d_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:currentState"/>, d_<xsl:value-of select="../../xmml:name"/>s);
 	gpuErrchkLaunch();
 
 	//GRID AND BLOCK SIZE FOR COMPACT
-	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, scatter_<xsl:value-of select="../../xmml:name"/>_Agents, no_sm, state_list_size);
+	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, scatter_<xsl:value-of select="../../xmml:name"/>_Agents, no_sm, state_list_size); 
 	gridSize = (state_list_size + blockSize - 1) / blockSize;
-
+	
 	//COMPACT CURRENT STATE LIST
 	thrust::exclusive_scan(thrust::cuda::par.on(stream), thrust::device_pointer_cast(d_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:currentState"/>->_scan_input), thrust::device_pointer_cast(d_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:currentState"/>->_scan_input) + h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count, thrust::device_pointer_cast(d_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:currentState"/>->_position));
 	//reset agent count
@@ -759,7 +761,7 @@ void <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>
 	gpuErrchk( cudaMemcpy( &amp;scan_last_included, &amp;d_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:currentState"/>->_scan_input[h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count-1], sizeof(int), cudaMemcpyDeviceToHost));
 	if (scan_last_included == 1)
 		h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:currentState"/>_count = scan_last_sum+1;
-	else
+	else		
 		h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:currentState"/>_count = scan_last_sum;
 	//Scatter into swap
 	scatter_<xsl:value-of select="../../xmml:name"/>_Agents&lt;&lt;&lt;gridSize, blockSize, 0, stream&gt;&gt;&gt;(d_<xsl:value-of select="../../xmml:name"/>s_swap, d_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:currentState"/>, 0, h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count);
@@ -769,8 +771,8 @@ void <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>
 	d_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:currentState"/> = d_<xsl:value-of select="../../xmml:name"/>s_swap;
 	d_<xsl:value-of select="../../xmml:name"/>s_swap = <xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:currentState"/>_temp;
 	//update the device count
-	gpuErrchk( cudaMemcpyToSymbol( d_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:currentState"/>_count, &amp;h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:currentState"/>_count, sizeof(int)));
-
+	gpuErrchk( cudaMemcpyToSymbol( d_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:currentState"/>_count, &amp;h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:currentState"/>_count, sizeof(int)));	
+		
 	//COMPACT WORKING STATE LIST
 	thrust::exclusive_scan(thrust::cuda::par.on(stream), thrust::device_pointer_cast(d_<xsl:value-of select="../../xmml:name"/>s->_scan_input), thrust::device_pointer_cast(d_<xsl:value-of select="../../xmml:name"/>s->_scan_input) + h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count, thrust::device_pointer_cast(d_<xsl:value-of select="../../xmml:name"/>s->_position));
 	//reset agent count
@@ -782,44 +784,44 @@ void <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>
 	//update working agent count after the scatter
 	if (scan_last_included == 1)
 		h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count = scan_last_sum+1;
-	else
+	else		
 		h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count = scan_last_sum;
     //use a temp pointer change working swap list with current state list
 	xmachine_memory_<xsl:value-of select="../../xmml:name"/>_list* <xsl:value-of select="../../xmml:name"/>s_temp = d_<xsl:value-of select="../../xmml:name"/>s;
 	d_<xsl:value-of select="../../xmml:name"/>s = d_<xsl:value-of select="../../xmml:name"/>s_swap;
 	d_<xsl:value-of select="../../xmml:name"/>s_swap = <xsl:value-of select="../../xmml:name"/>s_temp;
 	//update the device count
-	gpuErrchk( cudaMemcpyToSymbol( d_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count, &amp;h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count, sizeof(int)));
-
+	gpuErrchk( cudaMemcpyToSymbol( d_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count, &amp;h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count, sizeof(int)));	
+	
 	//CHECK WORKING LIST COUNT IS NOT EQUAL TO 0
 	if (h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count == 0)
 	{
 		return;
 	}
-
+	
 	<xsl:if test="../../gpu:type='continuous'">//Update the state list size for occupancy calculations
 	state_list_size = h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count;
 	</xsl:if>
-
+			
 	</xsl:if></xsl:when><xsl:when test="gpu:globalCondition">//THERE IS A GLOBAL CONDITION
-
+	
 	//COPY CURRENT STATE COUNT TO WORKING COUNT (host and device)
 	h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count = h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:currentState"/>_count;
-	gpuErrchk( cudaMemcpyToSymbol( d_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count, &amp;h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count, sizeof(int)));
-
+	gpuErrchk( cudaMemcpyToSymbol( d_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count, &amp;h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count, sizeof(int)));	
+	
 	//RESET SCAN INPUTS
 	//reset scan input for currentState
-	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, reset_<xsl:value-of select="../../xmml:name"/>_scan_input, no_sm, state_list_size);
+	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, reset_<xsl:value-of select="../../xmml:name"/>_scan_input, no_sm, state_list_size); 
 	gridSize = (state_list_size + blockSize - 1) / blockSize;
 	reset_<xsl:value-of select="../../xmml:name"/>_scan_input&lt;&lt;&lt;gridSize, blockSize, 0, stream&gt;&gt;&gt;(d_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:currentState"/>);
 	gpuErrchkLaunch();
-
+	
 	//APPLY FUNCTION FILTER
-	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, <xsl:value-of select="xmml:name"/>_function_filter, no_sm, state_list_size);
+	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, <xsl:value-of select="xmml:name"/>_function_filter, no_sm, state_list_size); 
 	gridSize = (state_list_size + blockSize - 1) / blockSize;
 	<xsl:value-of select="xmml:name"/>_function_filter&lt;&lt;&lt;gridSize, blockSize, 0, stream&gt;&gt;&gt;(d_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:currentState"/>);
 	gpuErrchkLaunch();
-
+	
 	//GET CONDTIONS TRUE COUNT FROM CURRENT STATE LIST
     thrust::exclusive_scan(thrust::cuda::par.on(stream), thrust::device_pointer_cast(d_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:currentState"/>->_scan_input),  thrust::device_pointer_cast(d_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:currentState"/>->_scan_input) + h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count, thrust::device_pointer_cast(d_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:currentState"/>->_position));
 	//reset agent count
@@ -828,7 +830,7 @@ void <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>
 	int global_conditions_true = 0;
 	if (scan_last_included == 1)
 		global_conditions_true = scan_last_sum+1;
-	else
+	else		
 		global_conditions_true = scan_last_sum;
 	//check if condition is true for all agents or if max condition count is reached
 	if ((global_conditions_true <xsl:choose><xsl:when test="gpu:globalCondition/gpu:mustEvaluateTo='true'">!</xsl:when><xsl:otherwise>=</xsl:otherwise></xsl:choose>= h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count)&amp;&amp;(h_<xsl:value-of select="xmml:name"/>_condition_count &lt; <xsl:value-of select="gpu:globalCondition/gpu:maxItterations"/>))
@@ -840,19 +842,19 @@ void <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>
 	{
 		printf("Global agent condition for <xsl:value-of select="xmml:name"/> function reached the maximum number of <xsl:value-of select="gpu:globalCondition/gpu:maxItterations"/> conditions\n");
 	}
-
+	
 	//RESET THE CONDITION COUNT
 	h_<xsl:value-of select="xmml:name"/>_condition_count = 0;
-
+	
 	//MAP CURRENT STATE TO WORKING LIST
 	xmachine_memory_<xsl:value-of select="../../xmml:name"/>_list* <xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:currentState"/>_temp = d_<xsl:value-of select="../../xmml:name"/>s;
 	d_<xsl:value-of select="../../xmml:name"/>s = d_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:currentState"/>;
 	d_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:currentState"/> = <xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:currentState"/>_temp;
 	//set current state count to 0
 	h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:currentState"/>_count = 0;
-	gpuErrchk( cudaMemcpyToSymbol( d_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count, &amp;h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count, sizeof(int)));
-
-
+	gpuErrchk( cudaMemcpyToSymbol( d_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count, &amp;h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count, sizeof(int)));	
+	
+	
 	</xsl:when><xsl:otherwise>//THERE IS NOT A FUNCTION CONDITION
 	//currentState maps to working list
 	xmachine_memory_<xsl:value-of select="../../xmml:name"/>_list* <xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:currentState"/>_temp = d_<xsl:value-of select="../../xmml:name"/>s;
@@ -860,13 +862,13 @@ void <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>
 	d_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:currentState"/> = <xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:currentState"/>_temp;
 	//set working count to current state count
 	h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count = h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:currentState"/>_count;
-	gpuErrchk( cudaMemcpyToSymbol( d_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count, &amp;h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count, sizeof(int)));
+	gpuErrchk( cudaMemcpyToSymbol( d_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count, &amp;h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count, sizeof(int)));	
 	//set current state count to 0
 	h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:currentState"/>_count = 0;
-	gpuErrchk( cudaMemcpyToSymbol( d_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:currentState"/>_count, &amp;h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:currentState"/>_count, sizeof(int)));
+	gpuErrchk( cudaMemcpyToSymbol( d_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:currentState"/>_count, &amp;h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:currentState"/>_count, sizeof(int)));	
 	</xsl:otherwise>
 	</xsl:choose>
-
+ 
 
 	//******************************** AGENT FUNCTION *******************************
 
@@ -877,7 +879,7 @@ void <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>
 		exit(EXIT_FAILURE);
 	}
 	</xsl:if></xsl:if>
-
+	
 	//calculate the grid block size for main agent function
 	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, GPUFLAME_<xsl:value-of select="xmml:name"/>, <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_sm_size, state_list_size);<xsl:if test="../../gpu:type='continuous'">
 	gridSize = (state_list_size + blockSize - 1) / blockSize;
@@ -891,8 +893,8 @@ void <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>
 	g.x = (int)sqrt(gridSize);
 	g.y = g.x;</xsl:if>
 	sm_size = <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_sm_size(blockSize);
-
-
+	
+	
 	<xsl:if test="xmml:inputs/gpu:input"><xsl:variable name="messageName" select="xmml:inputs/gpu:input/xmml:messageName"/>
 	<xsl:if test="../../gpu:type='discrete'"><xsl:for-each select="../../../../xmml:messages/gpu:message[xmml:name=$messageName]"><xsl:if test="gpu:partitioningDiscrete">
 	//check that the range is not greater than the square of the block size. If so then there will be too many uncoalesded reads
@@ -901,12 +903,12 @@ void <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>
 		exit(EXIT_FAILURE);
 	}
 	</xsl:if></xsl:for-each></xsl:if></xsl:if>
-
+	
 	<xsl:if test="xmml:inputs/gpu:input"><xsl:variable name="messageName" select="xmml:inputs/gpu:input/xmml:messageName"/>
 	//BIND APPROPRIATE MESSAGE INPUT VARIABLES TO TEXTURES (to make use of the texture cache)
 	<xsl:for-each select="../../../../xmml:messages/gpu:message[xmml:name=$messageName]">
 	<xsl:if test="gpu:partitioningDiscrete or gpu:partitioningSpatial">//any agent with discrete or partitioned message input uses texture caching
-	<xsl:for-each select="xmml:variables/gpu:variable">size_t tex_xmachine_message_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_byte_offset;
+	<xsl:for-each select="xmml:variables/gpu:variable">size_t tex_xmachine_message_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_byte_offset;    
 	gpuErrchk( cudaBindTexture(&amp;tex_xmachine_message_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_byte_offset, tex_xmachine_message_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>, d_<xsl:value-of select="../../xmml:name"/>s-><xsl:value-of select="xmml:name"/>, sizeof(<xsl:value-of select="xmml:type"/>)*xmachine_message_<xsl:value-of select="../../xmml:name"/>_MAX));
 	h_tex_xmachine_message_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_offset = (int)tex_xmachine_message_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_byte_offset / sizeof(<xsl:value-of select="xmml:type"/>);
 	gpuErrchk(cudaMemcpyToSymbol( d_tex_xmachine_message_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_offset, &amp;h_tex_xmachine_message_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_offset, sizeof(int)));
@@ -922,7 +924,7 @@ void <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>
 
 	</xsl:if></xsl:if>
 	</xsl:for-each></xsl:if>
-
+	
 	<xsl:if test="xmml:outputs/gpu:output"><xsl:variable name="messageName" select="xmml:outputs/gpu:output/xmml:messageName"/><xsl:variable name="outputType" select="xmml:outputs/gpu:output/gpu:type"/>
 	//SET THE OUTPUT MESSAGE TYPE FOR CONTINUOUS AGENTS
 	<xsl:if test="../../gpu:type='continuous'"><xsl:for-each select="../../../../xmml:messages/gpu:message[xmml:name=$messageName]">
@@ -930,22 +932,22 @@ void <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>
 	h_message_<xsl:value-of select="xmml:name"/>_output_type = <xsl:value-of select="$outputType"/>;
 	gpuErrchk( cudaMemcpyToSymbol( d_message_<xsl:value-of select="xmml:name"/>_output_type, &amp;h_message_<xsl:value-of select="xmml:name"/>_output_type, sizeof(int)));
 	<xsl:if test="$outputType='optional_message'">//message is optional so reset the swap
-	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, reset_<xsl:value-of select="xmml:name"/>_swaps, no_sm, state_list_size);
+	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, reset_<xsl:value-of select="xmml:name"/>_swaps, no_sm, state_list_size); 
 	gridSize = (state_list_size + blockSize - 1) / blockSize;
 	reset_<xsl:value-of select="xmml:name"/>_swaps&lt;&lt;&lt;gridSize, blockSize, 0, stream&gt;&gt;&gt;(d_<xsl:value-of select="xmml:name"/>s); <!-- Twin Karmakharm Change - Bug found, need to reset the actual message array and not the swap array -->
 	gpuErrchkLaunch();
 	</xsl:if></xsl:if></xsl:for-each>
 	</xsl:if></xsl:if>
-
-
+	
+	
 	<xsl:if test="../../gpu:type='continuous'"><xsl:if test="gpu:reallocate='true'">
-	//IF CONTINUOUS AGENT CAN REALLOCATE (process dead agents) THEN RESET AGENT SWAPS
-	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, reset_<xsl:value-of select="../../xmml:name"/>_scan_input, no_sm, state_list_size);
+	//IF CONTINUOUS AGENT CAN REALLOCATE (process dead agents) THEN RESET AGENT SWAPS	
+	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, reset_<xsl:value-of select="../../xmml:name"/>_scan_input, no_sm, state_list_size); 
 	gridSize = (state_list_size + blockSize - 1) / blockSize;
 	reset_<xsl:value-of select="../../xmml:name"/>_scan_input&lt;&lt;&lt;gridSize, blockSize, 0, stream&gt;&gt;&gt;(d_<xsl:value-of select="../../xmml:name"/>s);
 	gpuErrchkLaunch();
 	</xsl:if></xsl:if>
-
+	
 	//MAIN XMACHINE FUNCTION CALL (<xsl:value-of select="xmml:name"/>)
 	//Reallocate   : <xsl:choose><xsl:when test="gpu:reallocate='true'">true</xsl:when><xsl:otherwise>false</xsl:otherwise></xsl:choose>
 	//Input        : <xsl:value-of select="xmml:inputs/gpu:input/xmml:messageName"/>
@@ -956,7 +958,7 @@ void <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>
 		<xsl:if test="xmml:outputs/gpu:output">, d_<xsl:value-of select="xmml:outputs/gpu:output/xmml:messageName"/>s<xsl:if test="xmml:outputs/gpu:output/xmml:type='optional_message'">_swap</xsl:if></xsl:if>
 		<xsl:if test="gpu:RNG='true'">, d_rand48</xsl:if>);
 	gpuErrchkLaunch();
-
+	
 	<xsl:if test="xmml:inputs/gpu:input"><xsl:variable name="messageName" select="xmml:inputs/gpu:input/xmml:messageName"/>
 	//UNBIND MESSAGE INPUT VARIABLE TEXTURES
 	<xsl:for-each select="../../../../xmml:messages/gpu:message[xmml:name=$messageName]">
@@ -981,14 +983,14 @@ void <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>
 	<!-- end bug fix -->
     thrust::exclusive_scan(thrust::cuda::par.on(stream), thrust::device_pointer_cast(d_<xsl:value-of select="xmml:name"/>s_swap->_scan_input), thrust::device_pointer_cast(d_<xsl:value-of select="xmml:name"/>s_swap->_scan_input) + h_xmachine_memory_<xsl:value-of select="$xagentName"/>_count, thrust::device_pointer_cast(d_<xsl:value-of select="xmml:name"/>s_swap->_position));
 	//Scatter
-	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, scatter_optional_<xsl:value-of select="xmml:name"/>_messages, no_sm, state_list_size);
+	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, scatter_optional_<xsl:value-of select="xmml:name"/>_messages, no_sm, state_list_size); 
 	gridSize = (state_list_size + blockSize - 1) / blockSize;
 	scatter_optional_<xsl:value-of select="xmml:name"/>_messages&lt;&lt;&lt;gridSize, blockSize, 0, stream&gt;&gt;&gt;(d_<xsl:value-of select="xmml:name"/>s, d_<xsl:value-of select="xmml:name"/>s_swap);
 	gpuErrchkLaunch();
 	</xsl:if></xsl:if>
 	</xsl:for-each></xsl:if>
 	</xsl:if>
-
+	
 	<xsl:if test="xmml:outputs/gpu:output"><xsl:variable name="messageName" select="xmml:outputs/gpu:output/xmml:messageName"/><xsl:variable name="outputType" select="xmml:outputs/gpu:output/gpu:type"/><xsl:variable name="xagentName" select="../../xmml:name"/>
 	//UPDATE MESSAGE COUNTS FOR CONTINUOUS AGENTS WITH NON PARTITIONED MESSAGE OUTPUT <xsl:if test="../../gpu:type='continuous'">
 	<xsl:for-each select="../../../../xmml:messages/gpu:message[xmml:name=$messageName]">
@@ -1005,24 +1007,24 @@ void <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>
     </xsl:if><xsl:if test="$outputType='single_message'">
 	h_message_<xsl:value-of select="xmml:name"/>_count += h_xmachine_memory_<xsl:value-of select="$xagentName"/>_count;
 	</xsl:if>//Copy count to device
-	gpuErrchk( cudaMemcpyToSymbol( d_message_<xsl:value-of select="xmml:name"/>_count, &amp;h_message_<xsl:value-of select="xmml:name"/>_count, sizeof(int)));
+	gpuErrchk( cudaMemcpyToSymbol( d_message_<xsl:value-of select="xmml:name"/>_count, &amp;h_message_<xsl:value-of select="xmml:name"/>_count, sizeof(int)));	
 	</xsl:if>
 	</xsl:for-each>
 	</xsl:if>
 	</xsl:if>
-
+	
 	<xsl:if test="xmml:xagentOutputs/gpu:xagentOutput">
 	<xsl:variable name="xagent_output" select="xmml:xagentOutputs/gpu:xagentOutput/xmml:xagentName"/><xsl:if test="../../../gpu:xagent[xmml:name=$xagent_output]/gpu:type='continuous'">
     //COPY ANY AGENT COUNT BEFORE <xsl:value-of select="../../xmml:name"/> AGENTS ARE KILLED (needed for scatter)
 	int <xsl:value-of select="../../xmml:name"/>s_pre_death_count = h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count;
 	</xsl:if>
 	</xsl:if>
-
+	
 	<xsl:if test="../../gpu:type='continuous'"><xsl:if test="gpu:reallocate='true'">
-	//FOR CONTINUOUS AGENTS WITH REALLOCATION REMOVE POSSIBLE DEAD AGENTS
+	//FOR CONTINUOUS AGENTS WITH REALLOCATION REMOVE POSSIBLE DEAD AGENTS	
     thrust::exclusive_scan(thrust::cuda::par.on(stream), thrust::device_pointer_cast(d_<xsl:value-of select="../../xmml:name"/>s->_scan_input), thrust::device_pointer_cast(d_<xsl:value-of select="../../xmml:name"/>s->_scan_input) + h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count, thrust::device_pointer_cast(d_<xsl:value-of select="../../xmml:name"/>s->_position));
 	//Scatter into swap
-	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, scatter_<xsl:value-of select="../../xmml:name"/>_Agents, no_sm, state_list_size);
+	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, scatter_<xsl:value-of select="../../xmml:name"/>_Agents, no_sm, state_list_size); 
 	gridSize = (state_list_size + blockSize - 1) / blockSize;
 	scatter_<xsl:value-of select="../../xmml:name"/>_Agents&lt;&lt;&lt;gridSize, blockSize, 0, stream&gt;&gt;&gt;(d_<xsl:value-of select="../../xmml:name"/>s_swap, d_<xsl:value-of select="../../xmml:name"/>s, 0, h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count);
 	gpuErrchkLaunch();
@@ -1038,12 +1040,12 @@ void <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>
 	else
 		h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count = scan_last_sum;
 	//Copy count to device
-	gpuErrchk( cudaMemcpyToSymbol( d_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count, &amp;h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count, sizeof(int)));
+	gpuErrchk( cudaMemcpyToSymbol( d_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count, &amp;h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count, sizeof(int)));	
 	</xsl:if></xsl:if>
 
 	<xsl:if test="xmml:xagentOutputs/gpu:xagentOutput"><xsl:for-each select="xmml:xagentOutputs/gpu:xagentOutput">
 	<xsl:variable name="xagent_output" select="xmml:xagentName"/><xsl:if test="../../../../../gpu:xagent[xmml:name=$xagent_output]/gpu:type='continuous'">
-	//FOR <xsl:value-of select="xmml:xagentName"/> AGENT OUTPUT SCATTER AGENTS
+	//FOR <xsl:value-of select="xmml:xagentName"/> AGENT OUTPUT SCATTER AGENTS 
     thrust::exclusive_scan(thrust::cuda::par.on(stream), thrust::device_pointer_cast(d_<xsl:value-of select="xmml:xagentName"/>s_new->_scan_input), thrust::device_pointer_cast(d_<xsl:value-of select="xmml:xagentName"/>s_new->_scan_input) + <xsl:value-of select="../../../../xmml:name"/>s_pre_death_count, thrust::device_pointer_cast(d_<xsl:value-of select="xmml:xagentName"/>s_new->_position));
 	//reset agent count
 	int <xsl:value-of select="xmml:xagentName"/>_after_birth_count;
@@ -1059,16 +1061,16 @@ void <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>
 		exit(EXIT_FAILURE);
 	}
 	//Scatter into swap
-	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, scatter_<xsl:value-of select="xmml:xagentName"/>_Agents, no_sm, state_list_size);
+	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, scatter_<xsl:value-of select="xmml:xagentName"/>_Agents, no_sm, state_list_size); 
 	gridSize = (state_list_size + blockSize - 1) / blockSize;
 	scatter_<xsl:value-of select="xmml:xagentName"/>_Agents&lt;&lt;&lt;gridSize, blockSize, 0, stream&gt;&gt;&gt;(d_<xsl:value-of select="xmml:xagentName"/>s_<xsl:value-of select="xmml:state"/>, d_<xsl:value-of select="xmml:xagentName"/>s_new, h_xmachine_memory_<xsl:value-of select="xmml:xagentName"/>_<xsl:value-of select="xmml:state"/>_count, <xsl:value-of select="../../../../xmml:name"/>s_pre_death_count);
 	gpuErrchkLaunch();
 	//Copy count to device
 	h_xmachine_memory_<xsl:value-of select="xmml:xagentName"/>_<xsl:value-of select="xmml:state"/>_count = <xsl:value-of select="xmml:xagentName"/>_after_birth_count;
-	gpuErrchk( cudaMemcpyToSymbol( d_xmachine_memory_<xsl:value-of select="xmml:xagentName"/>_<xsl:value-of select="xmml:state"/>_count, &amp;h_xmachine_memory_<xsl:value-of select="xmml:xagentName"/>_<xsl:value-of select="xmml:state"/>_count, sizeof(int)));
+	gpuErrchk( cudaMemcpyToSymbol( d_xmachine_memory_<xsl:value-of select="xmml:xagentName"/>_<xsl:value-of select="xmml:state"/>_count, &amp;h_xmachine_memory_<xsl:value-of select="xmml:xagentName"/>_<xsl:value-of select="xmml:state"/>_count, sizeof(int)));	
 	</xsl:if></xsl:for-each>
 	</xsl:if>
-
+	
 	<xsl:if test="xmml:outputs/gpu:output"><xsl:variable name="messageName" select="xmml:outputs/gpu:output/xmml:messageName"/>
 	<xsl:for-each select="../../../../xmml:messages/gpu:message[xmml:name=$messageName]">
 	<xsl:if test="gpu:partitioningSpatial">
@@ -1078,23 +1080,23 @@ void <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>
     if (h_message_<xsl:value-of select="xmml:name"/>_count > 0){
 #ifdef FAST_ATOMIC_SORTING
       //USE ATOMICS TO BUILD PARTITION BOUNDARY
-	  cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, hist_<xsl:value-of select="xmml:name"/>_messages, no_sm, h_message_<xsl:value-of select="xmml:name"/>_count);
+	  cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, hist_<xsl:value-of select="xmml:name"/>_messages, no_sm, h_message_<xsl:value-of select="xmml:name"/>_count); 
 	  gridSize = (h_message_<xsl:value-of select="xmml:name"/>_count + blockSize - 1) / blockSize;
 	  hist_<xsl:value-of select="xmml:name"/>_messages&lt;&lt;&lt;gridSize, blockSize, 0, stream&gt;&gt;&gt;(d_xmachine_message_<xsl:value-of select="xmml:name"/>_local_bin_index, d_xmachine_message_<xsl:value-of select="xmml:name"/>_unsorted_index, d_<xsl:value-of select="xmml:name"/>_partition_matrix->end_or_count, d_<xsl:value-of select="xmml:name"/>s, h_message_<xsl:value-of select="xmml:name"/>_count);
 	  gpuErrchkLaunch();
-
+	
 	  thrust::device_ptr&lt;int&gt; ptr_count = thrust::device_pointer_cast(d_<xsl:value-of select="xmml:name"/>_partition_matrix->end_or_count);
 	  thrust::device_ptr&lt;int&gt; ptr_index = thrust::device_pointer_cast(d_<xsl:value-of select="xmml:name"/>_partition_matrix->start);
 	  thrust::exclusive_scan(thrust::cuda::par.on(stream), ptr_count, ptr_count + xmachine_message_<xsl:value-of select="xmml:name"/>_grid_size, ptr_index); // scan
-
-	  cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, reorder_<xsl:value-of select="xmml:name"/>_messages, no_sm, h_message_<xsl:value-of select="xmml:name"/>_count);
-	  gridSize = (h_message_<xsl:value-of select="xmml:name"/>_count + blockSize - 1) / blockSize; 	// Round up according to array size
+	
+	  cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, reorder_<xsl:value-of select="xmml:name"/>_messages, no_sm, h_message_<xsl:value-of select="xmml:name"/>_count); 
+	  gridSize = (h_message_<xsl:value-of select="xmml:name"/>_count + blockSize - 1) / blockSize; 	// Round up according to array size 
 	  reorder_<xsl:value-of select="xmml:name"/>_messages &lt;&lt;&lt;gridSize, blockSize, 0, stream&gt;&gt;&gt;(d_xmachine_message_<xsl:value-of select="xmml:name"/>_local_bin_index, d_xmachine_message_<xsl:value-of select="xmml:name"/>_unsorted_index, d_<xsl:value-of select="xmml:name"/>_partition_matrix->start, d_<xsl:value-of select="xmml:name"/>s, d_<xsl:value-of select="xmml:name"/>s_swap, h_message_<xsl:value-of select="xmml:name"/>_count);
 	  gpuErrchkLaunch();
 #else
 	  //HASH, SORT, REORDER AND BUILD PMB FOR SPATIAL PARTITIONING MESSAGE OUTPUTS
 	  //Get message hash values for sorting
-	  cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, hash_<xsl:value-of select="xmml:name"/>_messages, no_sm, h_message_<xsl:value-of select="xmml:name"/>_count);
+	  cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, hash_<xsl:value-of select="xmml:name"/>_messages, no_sm, h_message_<xsl:value-of select="xmml:name"/>_count); 
 	  gridSize = (h_message_<xsl:value-of select="xmml:name"/>_count + blockSize - 1) / blockSize;
 	  hash_<xsl:value-of select="xmml:name"/>_messages&lt;&lt;&lt;gridSize, blockSize, 0, stream&gt;&gt;&gt;(d_xmachine_message_<xsl:value-of select="xmml:name"/>_keys, d_xmachine_message_<xsl:value-of select="xmml:name"/>_values, d_<xsl:value-of select="xmml:name"/>s);
 	  gpuErrchkLaunch();
@@ -1103,7 +1105,7 @@ void <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>
 	  gpuErrchkLaunch();
 	  //reorder and build pcb
 	  gpuErrchk(cudaMemset(d_<xsl:value-of select="xmml:name"/>_partition_matrix->start, 0xffffffff, xmachine_message_<xsl:value-of select="xmml:name"/>_grid_size* sizeof(int)));
-	  cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, reorder_<xsl:value-of select="xmml:name"/>_messages, reorder_messages_sm_size, h_message_<xsl:value-of select="xmml:name"/>_count);
+	  cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, reorder_<xsl:value-of select="xmml:name"/>_messages, reorder_messages_sm_size, h_message_<xsl:value-of select="xmml:name"/>_count); 
 	  gridSize = (h_message_<xsl:value-of select="xmml:name"/>_count + blockSize - 1) / blockSize;
 	  int reorder_sm_size = reorder_messages_sm_size(blockSize);
 	  reorder_<xsl:value-of select="xmml:name"/>_messages&lt;&lt;&lt;gridSize, blockSize, reorder_sm_size, stream&gt;&gt;&gt;(d_xmachine_message_<xsl:value-of select="xmml:name"/>_keys, d_xmachine_message_<xsl:value-of select="xmml:name"/>_values, d_<xsl:value-of select="xmml:name"/>_partition_matrix, d_<xsl:value-of select="xmml:name"/>s, d_<xsl:value-of select="xmml:name"/>s_swap);
@@ -1117,7 +1119,7 @@ void <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>
 	</xsl:if>
 	</xsl:for-each>
 	</xsl:if>
-
+	
 	//************************ MOVE AGENTS TO NEXT STATE ****************************
     <xsl:choose>
     <xsl:when test="../../gpu:type='continuous'">
@@ -1127,13 +1129,13 @@ void <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>
 		exit(EXIT_FAILURE);
 	}
 	//append agents to next state list
-	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, append_<xsl:value-of select="../../xmml:name"/>_Agents, no_sm, state_list_size);
+	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, append_<xsl:value-of select="../../xmml:name"/>_Agents, no_sm, state_list_size); 
 	gridSize = (state_list_size + blockSize - 1) / blockSize;
 	append_<xsl:value-of select="../../xmml:name"/>_Agents&lt;&lt;&lt;gridSize, blockSize, 0, stream&gt;&gt;&gt;(d_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:nextState"/>, d_<xsl:value-of select="../../xmml:name"/>s, h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:nextState"/>_count, h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count);
 	gpuErrchkLaunch();
 	//update new state agent size
 	h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:nextState"/>_count += h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count;
-	gpuErrchk( cudaMemcpyToSymbol( d_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:nextState"/>_count, &amp;h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:nextState"/>_count, sizeof(int)));
+	gpuErrchk( cudaMemcpyToSymbol( d_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:nextState"/>_count, &amp;h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:nextState"/>_count, sizeof(int)));	
 	</xsl:when>
     <xsl:when test="../../gpu:type='discrete'">
     //currentState maps to working list
@@ -1142,22 +1144,22 @@ void <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>
 	d_<xsl:value-of select="../../xmml:name"/>s = <xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:currentState"/>_temp;
     //set current state count
 	h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:currentState"/>_count = h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count;
-	gpuErrchk( cudaMemcpyToSymbol( d_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:currentState"/>_count, &amp;h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:currentState"/>_count, sizeof(int)));
+	gpuErrchk( cudaMemcpyToSymbol( d_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:currentState"/>_count, &amp;h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:currentState"/>_count, sizeof(int)));	
 	</xsl:when>
   </xsl:choose>
-
+	
 }
 
 
 </xsl:for-each>
+    
 
-
-<xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent/xmml:states/gpu:state">
+<xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent/xmml:states/gpu:state"> 
 extern void reset_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_count()
 {
     h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_count = 0;
 }
 </xsl:for-each>
-
+    
 </xsl:template>
 </xsl:stylesheet>

--- a/FLAMEGPU/templates/simulation.xslt
+++ b/FLAMEGPU/templates/simulation.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:xmml="http://www.dcs.shef.ac.uk/~paul/XMML"
                 xmlns:gpu="http://www.dcs.shef.ac.uk/~paul/XMMLGPU">
 <xsl:output method="text" version="1.0" encoding="UTF-8" indent="yes" />
@@ -7,18 +7,18 @@
 /*
  * FLAME GPU v 1.4.0 for CUDA 6
  * Copyright 2015 University of Sheffield.
- * Author: Dr Paul Richmond 
+ * Author: Dr Paul Richmond
  * Contact: p.richmond@sheffield.ac.uk (http://www.paulrichmond.staff.shef.ac.uk)
  *
- * University of Sheffield retain all intellectual property and 
- * proprietary rights in and to this software and related documentation. 
- * Any use, reproduction, disclosure, or distribution of this software 
+ * University of Sheffield retain all intellectual property and
+ * proprietary rights in and to this software and related documentation.
+ * Any use, reproduction, disclosure, or distribution of this software
  * and related documentation without an express license agreement from
  * University of Sheffield is strictly prohibited.
  *
- * For terms of licence agreement please attached licence or view licence 
+ * For terms of licence agreement please attached licence or view licence
  * on www.flamegpu.com website.
- * 
+ *
  */
 
 //Disable internal thrust warnings about conversions
@@ -57,7 +57,7 @@
 #define gpuErrchk(ans) { gpuAssert((ans), __FILE__, __LINE__); }
 inline void gpuAssert(cudaError_t code, const char *file, int line, bool abort=true)
 {
-   if (code != cudaSuccess) 
+   if (code != cudaSuccess)
    {
       fprintf(stderr,"GPUassert: %s %s %d\n", cudaGetErrorString(code), file, line);
       if (abort) exit(code);
@@ -72,7 +72,7 @@ inline void gpuLaunchAssert(const char *file, int line, bool abort=true)
 #ifdef _DEBUG
 	gpuAssert( cudaDeviceSynchronize(), file, line );
 #endif
-   
+
 }
 
 /* SM padding and offset variables */
@@ -93,7 +93,7 @@ uint * d_xmachine_memory_<xsl:value-of select="xmml:name"/>_values;  /**&lt; Age
 /* <xsl:value-of select="../../xmml:name"/> state variables */
 xmachine_memory_<xsl:value-of select="../../xmml:name"/>_list* h_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:name"/>;      /**&lt; Pointer to agent list (population) on host*/
 xmachine_memory_<xsl:value-of select="../../xmml:name"/>_list* d_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:name"/>;      /**&lt; Pointer to agent list (population) on the device*/
-int h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_count;   /**&lt; Agent population size counter */ 
+int h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_count;   /**&lt; Agent population size counter */
 </xsl:for-each>
 </xsl:for-each>
 
@@ -129,7 +129,7 @@ int h_tex_xmachine_message_<xsl:value-of select="xmml:name"/>_pbm_start_offset;
 int h_tex_xmachine_message_<xsl:value-of select="xmml:name"/>_pbm_end_or_count_offset;
 </xsl:if></xsl:if>
 </xsl:for-each>
-  
+
 /* CUDA Streams for function layers */<xsl:for-each select="gpu:xmodel/xmml:layers/xmml:layer">
 <xsl:sort select="count(gpu:layerFunction)" order="descending"/>
 <xsl:if test="position() =1"> <!-- Get the layer with most functions -->
@@ -167,7 +167,7 @@ int scan_last_included;      /**&lt; Indicates if last sum value is included in 
  */
 void <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>(cudaStream_t &amp;stream);
 </xsl:for-each>
-  
+
 void setPaddingAndOffset()
 {
 	cudaDeviceProp deviceProp;
@@ -179,7 +179,7 @@ void setPaddingAndOffset()
 		printf("Error: There is no device supporting CUDA.\n");
 		exit(EXIT_FAILURE);
 	}
-    
+
     //check if double is used and supported
 #ifdef _DOUBLE_SUPPORT_REQUIRED_
 	printf("Simulation requires full precision double values\n");
@@ -187,7 +187,7 @@ void setPaddingAndOffset()
 		printf("Error: Hardware does not support full precision double values!\n");
 		exit(EXIT_FAILURE);
 	}
-    
+
 #endif
 
 	//check 32 or 64bit
@@ -203,10 +203,10 @@ void setPaddingAndOffset()
 
 	SM_START = 0;
 	PADDING = 0;
-  
+
 	//copy padding and offset to GPU
 	gpuErrchk(cudaMemcpyToSymbol( d_SM_START, &amp;SM_START, sizeof(int)));
-	gpuErrchk(cudaMemcpyToSymbol( d_PADDING, &amp;PADDING, sizeof(int)));     
+	gpuErrchk(cudaMemcpyToSymbol( d_PADDING, &amp;PADDING, sizeof(int)));
 }
 
 int is_sqr_pow2(int x){
@@ -216,14 +216,14 @@ int is_sqr_pow2(int x){
 
 int lowest_sqr_pow2(int x){
 	int l;
-	
+
 	//escape early if x is square power of 2
 	if (is_sqr_pow2(x))
 		return x;
-	
-	//lower bound		
+
+	//lower bound
 	l = (int)pow(4, floor(log(x)/log(4)));
-	
+
 	return l;
 }
 
@@ -243,10 +243,10 @@ void initialise(char * inputfile){
 
 	//set the padding and offset values depending on architecture and OS
 	setPaddingAndOffset();
-  
+
 
 	printf("Allocating Host and Device memory\n");
-  
+
 	/* Agent memory allocation (CPU) */<xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent">
 	int xmachine_<xsl:value-of select="xmml:name"/>_SoA_size = sizeof(xmachine_memory_<xsl:value-of select="xmml:name"/>_list);<xsl:for-each select="xmml:states/gpu:state">
 	h_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:name"/> = (xmachine_memory_<xsl:value-of select="../../xmml:name"/>_list*)malloc(xmachine_<xsl:value-of select="../../xmml:name"/>_SoA_size);</xsl:for-each></xsl:for-each>
@@ -259,11 +259,11 @@ void initialise(char * inputfile){
 	<xsl:variable name="xagent_output" select="xmml:xagentName"/><xsl:variable name="xagent_buffer" select="../../../../gpu:bufferSize"/><xsl:if test="../../../../../gpu:xagent[xmml:name=$xagent_output]/gpu:bufferSize&lt;$xagent_buffer">
 	printf("ERROR: <xsl:value-of select="$xagent_output"/> agent buffer is too small to be used for output by <xsl:value-of select="../../../../xmml:name"/> agent in <xsl:value-of select="../../xmml:name"/> function!\n");
 	exit(EXIT_FAILURE);
-	</xsl:if>    
+	</xsl:if>
 	</xsl:for-each>
-    
+
 	<xsl:for-each select="gpu:xmodel/xmml:messages/gpu:message"><xsl:if test="gpu:partitioningDiscrete">
-	
+
 	/* Set discrete <xsl:value-of select="xmml:name"/> message variables (range, width)*/
 	h_message_<xsl:value-of select="xmml:name"/>_range = <xsl:value-of select="gpu:partitioningDiscrete/gpu:radius"/>; //from xml
 	h_message_<xsl:value-of select="xmml:name"/>_width = (int)floor(sqrt((float)xmachine_message_<xsl:value-of select="xmml:name"/>_MAX));
@@ -272,24 +272,24 @@ void initialise(char * inputfile){
 		printf("ERROR: <xsl:value-of select="xmml:name"/> message max must be a square power of 2 for a 2D discrete message grid!\n");
 		exit(EXIT_FAILURE);
 	}
-	gpuErrchk(cudaMemcpyToSymbol( d_message_<xsl:value-of select="xmml:name"/>_range, &amp;h_message_<xsl:value-of select="xmml:name"/>_range, sizeof(int)));	
+	gpuErrchk(cudaMemcpyToSymbol( d_message_<xsl:value-of select="xmml:name"/>_range, &amp;h_message_<xsl:value-of select="xmml:name"/>_range, sizeof(int)));
 	gpuErrchk(cudaMemcpyToSymbol( d_message_<xsl:value-of select="xmml:name"/>_width, &amp;h_message_<xsl:value-of select="xmml:name"/>_width, sizeof(int)));
 	</xsl:if><xsl:if test="gpu:partitioningSpatial">
-			
+
 	/* Set spatial partitioning <xsl:value-of select="xmml:name"/> message variables (min_bounds, max_bounds)*/
 	h_message_<xsl:value-of select="xmml:name"/>_radius = (float)<xsl:value-of select="gpu:partitioningSpatial/gpu:radius"/>;
-	gpuErrchk(cudaMemcpyToSymbol( d_message_<xsl:value-of select="xmml:name"/>_radius, &amp;h_message_<xsl:value-of select="xmml:name"/>_radius, sizeof(float)));	
+	gpuErrchk(cudaMemcpyToSymbol( d_message_<xsl:value-of select="xmml:name"/>_radius, &amp;h_message_<xsl:value-of select="xmml:name"/>_radius, sizeof(float)));
 	    h_message_<xsl:value-of select="xmml:name"/>_min_bounds = glm::vec3((float)<xsl:value-of select="gpu:partitioningSpatial/gpu:xmin"/>, (float)<xsl:value-of select="gpu:partitioningSpatial/gpu:ymin"/>, (float)<xsl:value-of select="gpu:partitioningSpatial/gpu:zmin"/>);
-	gpuErrchk(cudaMemcpyToSymbol( d_message_<xsl:value-of select="xmml:name"/>_min_bounds, &amp;h_message_<xsl:value-of select="xmml:name"/>_min_bounds, sizeof(glm::vec3)));	
+	gpuErrchk(cudaMemcpyToSymbol( d_message_<xsl:value-of select="xmml:name"/>_min_bounds, &amp;h_message_<xsl:value-of select="xmml:name"/>_min_bounds, sizeof(glm::vec3)));
 	h_message_<xsl:value-of select="xmml:name"/>_max_bounds = glm::vec3((float)<xsl:value-of select="gpu:partitioningSpatial/gpu:xmax"/>, (float)<xsl:value-of select="gpu:partitioningSpatial/gpu:ymax"/>, (float)<xsl:value-of select="gpu:partitioningSpatial/gpu:zmax"/>);
-	gpuErrchk(cudaMemcpyToSymbol( d_message_<xsl:value-of select="xmml:name"/>_max_bounds, &amp;h_message_<xsl:value-of select="xmml:name"/>_max_bounds, sizeof(glm::vec3)));	
+	gpuErrchk(cudaMemcpyToSymbol( d_message_<xsl:value-of select="xmml:name"/>_max_bounds, &amp;h_message_<xsl:value-of select="xmml:name"/>_max_bounds, sizeof(glm::vec3)));
 	h_message_<xsl:value-of select="xmml:name"/>_partitionDim.x = (int)ceil((h_message_<xsl:value-of select="xmml:name"/>_max_bounds.x - h_message_<xsl:value-of select="xmml:name"/>_min_bounds.x)/h_message_<xsl:value-of select="xmml:name"/>_radius);
 	h_message_<xsl:value-of select="xmml:name"/>_partitionDim.y = (int)ceil((h_message_<xsl:value-of select="xmml:name"/>_max_bounds.y - h_message_<xsl:value-of select="xmml:name"/>_min_bounds.y)/h_message_<xsl:value-of select="xmml:name"/>_radius);
 	h_message_<xsl:value-of select="xmml:name"/>_partitionDim.z = (int)ceil((h_message_<xsl:value-of select="xmml:name"/>_max_bounds.z - h_message_<xsl:value-of select="xmml:name"/>_min_bounds.z)/h_message_<xsl:value-of select="xmml:name"/>_radius);
-	gpuErrchk(cudaMemcpyToSymbol( d_message_<xsl:value-of select="xmml:name"/>_partitionDim, &amp;h_message_<xsl:value-of select="xmml:name"/>_partitionDim, sizeof(glm::ivec3)));	
+	gpuErrchk(cudaMemcpyToSymbol( d_message_<xsl:value-of select="xmml:name"/>_partitionDim, &amp;h_message_<xsl:value-of select="xmml:name"/>_partitionDim, sizeof(glm::ivec3)));
 	</xsl:if></xsl:for-each>
-	
-	
+
+
 	<xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent"><xsl:if test="gpu:type='discrete'">
 	/* Check that population size is a square power of 2*/
 	if (!is_sqr_pow2(xmachine_memory_<xsl:value-of select="xmml:name"/>_MAX)){
@@ -301,7 +301,7 @@ void initialise(char * inputfile){
 
 	//read initial states
 	readInitialStates(inputfile, <xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent">h_<xsl:value-of select="xmml:name"/>s_<xsl:value-of select="xmml:states/xmml:initialState"/>, &amp;h_xmachine_memory_<xsl:value-of select="xmml:name"/>_<xsl:value-of select="xmml:states/xmml:initialState"/>_count<xsl:if test="position()!=last()">, </xsl:if></xsl:for-each>);
-	
+
 	<xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent">
 	/* <xsl:value-of select="xmml:name"/> Agent memory allocation (GPU) */
 	gpuErrchk( cudaMalloc( (void**) &amp;d_<xsl:value-of select="xmml:name"/>s, xmachine_<xsl:value-of select="xmml:name"/>_SoA_size));
@@ -330,7 +330,7 @@ void initialise(char * inputfile){
 	gpuErrchk( cudaMalloc( (void**) &amp;d_xmachine_message_<xsl:value-of select="xmml:name"/>_keys, xmachine_message_<xsl:value-of select="xmml:name"/>_MAX* sizeof(uint)));
 	gpuErrchk( cudaMalloc( (void**) &amp;d_xmachine_message_<xsl:value-of select="xmml:name"/>_values, xmachine_message_<xsl:value-of select="xmml:name"/>_MAX* sizeof(uint)));
 #endif</xsl:if><xsl:text>
-	</xsl:text></xsl:for-each>	
+	</xsl:text></xsl:for-each>
 
 	/*Set global condition counts*/<xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent/xmml:functions/gpu:function/gpu:condition">
 	h_<xsl:value-of select="../xmml:name"/>_condition_false_count = 0;
@@ -387,7 +387,7 @@ void initialise(char * inputfile){
 	printf("Instrumentation: <xsl:value-of select="gpu:name"/> = %f (ms)\n", instrument_milliseconds);
 #endif
 	</xsl:for-each>
-  
+
   /* Init CUDA Streams for function layers */
   <xsl:for-each select="gpu:xmodel/xmml:layers/xmml:layer">
   <xsl:sort select="count(gpu:layerFunction)" order="descending"/>
@@ -403,7 +403,7 @@ void initialise(char * inputfile){
 		printf("Init agent_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_count: %u\n",get_agent_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_count());
 	</xsl:for-each>
 #endif
-} 
+}
 
 <xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent"><xsl:if test="gpu:type='continuous'"> <xsl:for-each select="xmml:states/gpu:state">
 void sort_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:name"/>(void (*generate_key_value_pairs)(unsigned int* keys, unsigned int* values, xmachine_memory_<xsl:value-of select="../../xmml:name"/>_list* agents))
@@ -413,8 +413,8 @@ void sort_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:n
 	int gridSize;
 
 	//generate sort keys
-	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, generate_key_value_pairs, no_sm, h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_count); 
-	gridSize = (h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_count + blockSize - 1) / blockSize;    // Round up according to array size 
+	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, generate_key_value_pairs, no_sm, h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_count);
+	gridSize = (h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_count + blockSize - 1) / blockSize;    // Round up according to array size
 	generate_key_value_pairs&lt;&lt;&lt;gridSize, blockSize&gt;&gt;&gt;(d_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_keys, d_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_values, d_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:name"/>);
 	gpuErrchkLaunch();
 
@@ -423,15 +423,15 @@ void sort_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:n
 	gpuErrchkLaunch();
 
 	//reorder agents
-	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, reorder_<xsl:value-of select="../../xmml:name"/>_agents, no_sm, h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_count); 
-	gridSize = (h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_count + blockSize - 1) / blockSize;    // Round up according to array size 
+	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, reorder_<xsl:value-of select="../../xmml:name"/>_agents, no_sm, h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_count);
+	gridSize = (h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_count + blockSize - 1) / blockSize;    // Round up according to array size
 	reorder_<xsl:value-of select="../../xmml:name"/>_agents&lt;&lt;&lt;gridSize, blockSize&gt;&gt;&gt;(d_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_values, d_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:name"/>, d_<xsl:value-of select="../../xmml:name"/>s_swap);
 	gpuErrchkLaunch();
 
 	//swap
 	xmachine_memory_<xsl:value-of select="../../xmml:name"/>_list* d_<xsl:value-of select="../../xmml:name"/>s_temp = d_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:name"/>;
 	d_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:name"/> = d_<xsl:value-of select="../../xmml:name"/>s_swap;
-	d_<xsl:value-of select="../../xmml:name"/>s_swap = d_<xsl:value-of select="../../xmml:name"/>s_temp;	
+	d_<xsl:value-of select="../../xmml:name"/>s_swap = d_<xsl:value-of select="../../xmml:name"/>s_temp;
 }
 </xsl:for-each></xsl:if></xsl:for-each>
 
@@ -444,7 +444,7 @@ void cleanup(){
 #endif
 
 	<xsl:value-of select="gpu:name"/>();
-	
+
 #if defined(INSTRUMENT_EXIT_FUNCTIONS) &amp;&amp; INSTRUMENT_EXIT_FUNCTIONS
 	cudaEventRecord(instrument_stop);
 	cudaEventSynchronize(instrument_stop);
@@ -480,7 +480,7 @@ void cleanup(){
 	gpuErrchk(cudaFree(d_xmachine_message_<xsl:value-of select="xmml:name"/>_values));
 #endif</xsl:if><xsl:text>
 	</xsl:text></xsl:for-each>
-  
+
   /* CUDA Streams for function layers */
   <xsl:for-each select="gpu:xmodel/xmml:layers/xmml:layer">
   <xsl:sort select="count(gpu:layerFunction)" order="descending"/>
@@ -530,7 +530,7 @@ void singleIteration(){
 #endif
 	</xsl:for-each></xsl:for-each>cudaDeviceSynchronize();
   </xsl:for-each>
-    
+
     /* Call all step functions */
 	<xsl:for-each select="gpu:xmodel/gpu:environment/gpu:stepFunctions/gpu:stepFunction">
 #if defined(INSTRUMENT_STEP_FUNCTIONS) &amp;&amp; INSTRUMENT_STEP_FUNCTIONS
@@ -596,7 +596,7 @@ const <xsl:value-of select="xmml:type"/>* get_<xsl:value-of select="xmml:name"/>
 
 /* Agent data access functions*/
 <xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent">
-    
+
 int get_agent_<xsl:value-of select="xmml:name"/>_MAX_count(){
     return xmachine_memory_<xsl:value-of select="xmml:name"/>_MAX;
 }
@@ -605,7 +605,7 @@ int get_agent_<xsl:value-of select="xmml:name"/>_MAX_count(){
 int get_agent_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_count(){
 	<xsl:if test="../../gpu:type='continuous'">//continuous agent
 	return h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_count;
-	</xsl:if><xsl:if test="../../gpu:type='discrete'">//discrete agent 
+	</xsl:if><xsl:if test="../../gpu:type='discrete'">//discrete agent
 	return xmachine_memory_<xsl:value-of select="../../xmml:name"/>_MAX;</xsl:if>
 }
 
@@ -657,7 +657,7 @@ int get_<xsl:value-of select="xmml:name"/>_population_width(){
 /* Agent functions */
 
 <xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent/xmml:functions/gpu:function">
-	
+
 /* Shared memory size calculator for agent function */
 int <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_sm_size(int blockSize){
 	int sm_size;
@@ -703,15 +703,13 @@ void <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>
 	dim3 g; //grid for agent func
 	dim3 b; //block for agent func
 
-	
+
 	//CHECK THE CURRENT STATE LIST COUNT IS NOT EQUAL TO 0
-	<xsl:if test="../../gpu:type='continuous'">
 	if (h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:currentState"/>_count == 0)
 	{
 		return;
 	}
-	</xsl:if>
-	
+
 	//SET SM size to 0 and save state list size for occupancy calculations
 	sm_size = SM_START;
 	state_list_size = h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:currentState"/>_count;
@@ -720,7 +718,7 @@ void <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>
 	<xsl:for-each select="xmml:xagentOutputs/gpu:xagentOutput">
 	<xsl:variable name="xagent_output" select="xmml:xagentName"/><xsl:if test="../../../../../gpu:xagent[xmml:name=$xagent_output]/gpu:type='continuous'">
 	//FOR <xsl:value-of select="xmml:xagentName"/> AGENT OUTPUT, RESET THE AGENT NEW LIST SCAN INPUT
-	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, reset_<xsl:value-of select="xmml:xagentName"/>_scan_input, no_sm, state_list_size); 
+	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, reset_<xsl:value-of select="xmml:xagentName"/>_scan_input, no_sm, state_list_size);
 	gridSize = (state_list_size + blockSize - 1) / blockSize;
 	reset_<xsl:value-of select="xmml:xagentName"/>_scan_input&lt;&lt;&lt;gridSize, blockSize, 0, stream&gt;&gt;&gt;(d_<xsl:value-of select="xmml:xagentName"/>s_new);
 	gpuErrchkLaunch();
@@ -729,14 +727,14 @@ void <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>
 	//******************************** AGENT FUNCTION CONDITION *********************
 	<xsl:choose>
 	<xsl:when test="xmml:condition"><xsl:if test="../../gpu:type='continuous'">//CONTINUOUS AGENT FUNCTION AND THERE IS A FUNCTION CONDITION
-  	
+
 	//COPY CURRENT STATE COUNT TO WORKING COUNT (host and device)
 	h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count = h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:currentState"/>_count;
-	gpuErrchk( cudaMemcpyToSymbol( d_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count, &amp;h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count, sizeof(int)));	
-	
+	gpuErrchk( cudaMemcpyToSymbol( d_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count, &amp;h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count, sizeof(int)));
+
 	//RESET SCAN INPUTS
 	//reset scan input for currentState
-	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, reset_<xsl:value-of select="../../xmml:name"/>_scan_input, no_sm, state_list_size); 
+	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, reset_<xsl:value-of select="../../xmml:name"/>_scan_input, no_sm, state_list_size);
 	gridSize = (state_list_size + blockSize - 1) / blockSize;
 	reset_<xsl:value-of select="../../xmml:name"/>_scan_input&lt;&lt;&lt;gridSize, blockSize, 0, stream&gt;&gt;&gt;(d_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:currentState"/>);
 	gpuErrchkLaunch();
@@ -745,15 +743,15 @@ void <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>
 	gpuErrchkLaunch();
 
 	//APPLY FUNCTION FILTER
-	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, <xsl:value-of select="xmml:name"/>_function_filter, no_sm, state_list_size); 
+	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, <xsl:value-of select="xmml:name"/>_function_filter, no_sm, state_list_size);
 	gridSize = (state_list_size + blockSize - 1) / blockSize;
 	<xsl:value-of select="xmml:name"/>_function_filter&lt;&lt;&lt;gridSize, blockSize, 0, stream&gt;&gt;&gt;(d_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:currentState"/>, d_<xsl:value-of select="../../xmml:name"/>s);
 	gpuErrchkLaunch();
 
 	//GRID AND BLOCK SIZE FOR COMPACT
-	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, scatter_<xsl:value-of select="../../xmml:name"/>_Agents, no_sm, state_list_size); 
+	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, scatter_<xsl:value-of select="../../xmml:name"/>_Agents, no_sm, state_list_size);
 	gridSize = (state_list_size + blockSize - 1) / blockSize;
-	
+
 	//COMPACT CURRENT STATE LIST
 	thrust::exclusive_scan(thrust::cuda::par.on(stream), thrust::device_pointer_cast(d_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:currentState"/>->_scan_input), thrust::device_pointer_cast(d_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:currentState"/>->_scan_input) + h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count, thrust::device_pointer_cast(d_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:currentState"/>->_position));
 	//reset agent count
@@ -761,7 +759,7 @@ void <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>
 	gpuErrchk( cudaMemcpy( &amp;scan_last_included, &amp;d_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:currentState"/>->_scan_input[h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count-1], sizeof(int), cudaMemcpyDeviceToHost));
 	if (scan_last_included == 1)
 		h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:currentState"/>_count = scan_last_sum+1;
-	else		
+	else
 		h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:currentState"/>_count = scan_last_sum;
 	//Scatter into swap
 	scatter_<xsl:value-of select="../../xmml:name"/>_Agents&lt;&lt;&lt;gridSize, blockSize, 0, stream&gt;&gt;&gt;(d_<xsl:value-of select="../../xmml:name"/>s_swap, d_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:currentState"/>, 0, h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count);
@@ -771,8 +769,8 @@ void <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>
 	d_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:currentState"/> = d_<xsl:value-of select="../../xmml:name"/>s_swap;
 	d_<xsl:value-of select="../../xmml:name"/>s_swap = <xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:currentState"/>_temp;
 	//update the device count
-	gpuErrchk( cudaMemcpyToSymbol( d_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:currentState"/>_count, &amp;h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:currentState"/>_count, sizeof(int)));	
-		
+	gpuErrchk( cudaMemcpyToSymbol( d_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:currentState"/>_count, &amp;h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:currentState"/>_count, sizeof(int)));
+
 	//COMPACT WORKING STATE LIST
 	thrust::exclusive_scan(thrust::cuda::par.on(stream), thrust::device_pointer_cast(d_<xsl:value-of select="../../xmml:name"/>s->_scan_input), thrust::device_pointer_cast(d_<xsl:value-of select="../../xmml:name"/>s->_scan_input) + h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count, thrust::device_pointer_cast(d_<xsl:value-of select="../../xmml:name"/>s->_position));
 	//reset agent count
@@ -784,44 +782,44 @@ void <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>
 	//update working agent count after the scatter
 	if (scan_last_included == 1)
 		h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count = scan_last_sum+1;
-	else		
+	else
 		h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count = scan_last_sum;
     //use a temp pointer change working swap list with current state list
 	xmachine_memory_<xsl:value-of select="../../xmml:name"/>_list* <xsl:value-of select="../../xmml:name"/>s_temp = d_<xsl:value-of select="../../xmml:name"/>s;
 	d_<xsl:value-of select="../../xmml:name"/>s = d_<xsl:value-of select="../../xmml:name"/>s_swap;
 	d_<xsl:value-of select="../../xmml:name"/>s_swap = <xsl:value-of select="../../xmml:name"/>s_temp;
 	//update the device count
-	gpuErrchk( cudaMemcpyToSymbol( d_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count, &amp;h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count, sizeof(int)));	
-	
+	gpuErrchk( cudaMemcpyToSymbol( d_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count, &amp;h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count, sizeof(int)));
+
 	//CHECK WORKING LIST COUNT IS NOT EQUAL TO 0
 	if (h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count == 0)
 	{
 		return;
 	}
-	
+
 	<xsl:if test="../../gpu:type='continuous'">//Update the state list size for occupancy calculations
 	state_list_size = h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count;
 	</xsl:if>
-			
+
 	</xsl:if></xsl:when><xsl:when test="gpu:globalCondition">//THERE IS A GLOBAL CONDITION
-	
+
 	//COPY CURRENT STATE COUNT TO WORKING COUNT (host and device)
 	h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count = h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:currentState"/>_count;
-	gpuErrchk( cudaMemcpyToSymbol( d_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count, &amp;h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count, sizeof(int)));	
-	
+	gpuErrchk( cudaMemcpyToSymbol( d_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count, &amp;h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count, sizeof(int)));
+
 	//RESET SCAN INPUTS
 	//reset scan input for currentState
-	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, reset_<xsl:value-of select="../../xmml:name"/>_scan_input, no_sm, state_list_size); 
+	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, reset_<xsl:value-of select="../../xmml:name"/>_scan_input, no_sm, state_list_size);
 	gridSize = (state_list_size + blockSize - 1) / blockSize;
 	reset_<xsl:value-of select="../../xmml:name"/>_scan_input&lt;&lt;&lt;gridSize, blockSize, 0, stream&gt;&gt;&gt;(d_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:currentState"/>);
 	gpuErrchkLaunch();
-	
+
 	//APPLY FUNCTION FILTER
-	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, <xsl:value-of select="xmml:name"/>_function_filter, no_sm, state_list_size); 
+	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, <xsl:value-of select="xmml:name"/>_function_filter, no_sm, state_list_size);
 	gridSize = (state_list_size + blockSize - 1) / blockSize;
 	<xsl:value-of select="xmml:name"/>_function_filter&lt;&lt;&lt;gridSize, blockSize, 0, stream&gt;&gt;&gt;(d_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:currentState"/>);
 	gpuErrchkLaunch();
-	
+
 	//GET CONDTIONS TRUE COUNT FROM CURRENT STATE LIST
     thrust::exclusive_scan(thrust::cuda::par.on(stream), thrust::device_pointer_cast(d_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:currentState"/>->_scan_input),  thrust::device_pointer_cast(d_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:currentState"/>->_scan_input) + h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count, thrust::device_pointer_cast(d_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:currentState"/>->_position));
 	//reset agent count
@@ -830,7 +828,7 @@ void <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>
 	int global_conditions_true = 0;
 	if (scan_last_included == 1)
 		global_conditions_true = scan_last_sum+1;
-	else		
+	else
 		global_conditions_true = scan_last_sum;
 	//check if condition is true for all agents or if max condition count is reached
 	if ((global_conditions_true <xsl:choose><xsl:when test="gpu:globalCondition/gpu:mustEvaluateTo='true'">!</xsl:when><xsl:otherwise>=</xsl:otherwise></xsl:choose>= h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count)&amp;&amp;(h_<xsl:value-of select="xmml:name"/>_condition_count &lt; <xsl:value-of select="gpu:globalCondition/gpu:maxItterations"/>))
@@ -842,19 +840,19 @@ void <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>
 	{
 		printf("Global agent condition for <xsl:value-of select="xmml:name"/> function reached the maximum number of <xsl:value-of select="gpu:globalCondition/gpu:maxItterations"/> conditions\n");
 	}
-	
+
 	//RESET THE CONDITION COUNT
 	h_<xsl:value-of select="xmml:name"/>_condition_count = 0;
-	
+
 	//MAP CURRENT STATE TO WORKING LIST
 	xmachine_memory_<xsl:value-of select="../../xmml:name"/>_list* <xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:currentState"/>_temp = d_<xsl:value-of select="../../xmml:name"/>s;
 	d_<xsl:value-of select="../../xmml:name"/>s = d_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:currentState"/>;
 	d_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:currentState"/> = <xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:currentState"/>_temp;
 	//set current state count to 0
 	h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:currentState"/>_count = 0;
-	gpuErrchk( cudaMemcpyToSymbol( d_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count, &amp;h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count, sizeof(int)));	
-	
-	
+	gpuErrchk( cudaMemcpyToSymbol( d_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count, &amp;h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count, sizeof(int)));
+
+
 	</xsl:when><xsl:otherwise>//THERE IS NOT A FUNCTION CONDITION
 	//currentState maps to working list
 	xmachine_memory_<xsl:value-of select="../../xmml:name"/>_list* <xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:currentState"/>_temp = d_<xsl:value-of select="../../xmml:name"/>s;
@@ -862,13 +860,13 @@ void <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>
 	d_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:currentState"/> = <xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:currentState"/>_temp;
 	//set working count to current state count
 	h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count = h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:currentState"/>_count;
-	gpuErrchk( cudaMemcpyToSymbol( d_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count, &amp;h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count, sizeof(int)));	
+	gpuErrchk( cudaMemcpyToSymbol( d_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count, &amp;h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count, sizeof(int)));
 	//set current state count to 0
 	h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:currentState"/>_count = 0;
-	gpuErrchk( cudaMemcpyToSymbol( d_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:currentState"/>_count, &amp;h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:currentState"/>_count, sizeof(int)));	
+	gpuErrchk( cudaMemcpyToSymbol( d_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:currentState"/>_count, &amp;h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:currentState"/>_count, sizeof(int)));
 	</xsl:otherwise>
 	</xsl:choose>
- 
+
 
 	//******************************** AGENT FUNCTION *******************************
 
@@ -879,7 +877,7 @@ void <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>
 		exit(EXIT_FAILURE);
 	}
 	</xsl:if></xsl:if>
-	
+
 	//calculate the grid block size for main agent function
 	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, GPUFLAME_<xsl:value-of select="xmml:name"/>, <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_sm_size, state_list_size);<xsl:if test="../../gpu:type='continuous'">
 	gridSize = (state_list_size + blockSize - 1) / blockSize;
@@ -893,8 +891,8 @@ void <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>
 	g.x = (int)sqrt(gridSize);
 	g.y = g.x;</xsl:if>
 	sm_size = <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_sm_size(blockSize);
-	
-	
+
+
 	<xsl:if test="xmml:inputs/gpu:input"><xsl:variable name="messageName" select="xmml:inputs/gpu:input/xmml:messageName"/>
 	<xsl:if test="../../gpu:type='discrete'"><xsl:for-each select="../../../../xmml:messages/gpu:message[xmml:name=$messageName]"><xsl:if test="gpu:partitioningDiscrete">
 	//check that the range is not greater than the square of the block size. If so then there will be too many uncoalesded reads
@@ -903,12 +901,12 @@ void <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>
 		exit(EXIT_FAILURE);
 	}
 	</xsl:if></xsl:for-each></xsl:if></xsl:if>
-	
+
 	<xsl:if test="xmml:inputs/gpu:input"><xsl:variable name="messageName" select="xmml:inputs/gpu:input/xmml:messageName"/>
 	//BIND APPROPRIATE MESSAGE INPUT VARIABLES TO TEXTURES (to make use of the texture cache)
 	<xsl:for-each select="../../../../xmml:messages/gpu:message[xmml:name=$messageName]">
 	<xsl:if test="gpu:partitioningDiscrete or gpu:partitioningSpatial">//any agent with discrete or partitioned message input uses texture caching
-	<xsl:for-each select="xmml:variables/gpu:variable">size_t tex_xmachine_message_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_byte_offset;    
+	<xsl:for-each select="xmml:variables/gpu:variable">size_t tex_xmachine_message_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_byte_offset;
 	gpuErrchk( cudaBindTexture(&amp;tex_xmachine_message_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_byte_offset, tex_xmachine_message_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>, d_<xsl:value-of select="../../xmml:name"/>s-><xsl:value-of select="xmml:name"/>, sizeof(<xsl:value-of select="xmml:type"/>)*xmachine_message_<xsl:value-of select="../../xmml:name"/>_MAX));
 	h_tex_xmachine_message_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_offset = (int)tex_xmachine_message_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_byte_offset / sizeof(<xsl:value-of select="xmml:type"/>);
 	gpuErrchk(cudaMemcpyToSymbol( d_tex_xmachine_message_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_offset, &amp;h_tex_xmachine_message_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_offset, sizeof(int)));
@@ -924,7 +922,7 @@ void <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>
 
 	</xsl:if></xsl:if>
 	</xsl:for-each></xsl:if>
-	
+
 	<xsl:if test="xmml:outputs/gpu:output"><xsl:variable name="messageName" select="xmml:outputs/gpu:output/xmml:messageName"/><xsl:variable name="outputType" select="xmml:outputs/gpu:output/gpu:type"/>
 	//SET THE OUTPUT MESSAGE TYPE FOR CONTINUOUS AGENTS
 	<xsl:if test="../../gpu:type='continuous'"><xsl:for-each select="../../../../xmml:messages/gpu:message[xmml:name=$messageName]">
@@ -932,22 +930,22 @@ void <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>
 	h_message_<xsl:value-of select="xmml:name"/>_output_type = <xsl:value-of select="$outputType"/>;
 	gpuErrchk( cudaMemcpyToSymbol( d_message_<xsl:value-of select="xmml:name"/>_output_type, &amp;h_message_<xsl:value-of select="xmml:name"/>_output_type, sizeof(int)));
 	<xsl:if test="$outputType='optional_message'">//message is optional so reset the swap
-	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, reset_<xsl:value-of select="xmml:name"/>_swaps, no_sm, state_list_size); 
+	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, reset_<xsl:value-of select="xmml:name"/>_swaps, no_sm, state_list_size);
 	gridSize = (state_list_size + blockSize - 1) / blockSize;
 	reset_<xsl:value-of select="xmml:name"/>_swaps&lt;&lt;&lt;gridSize, blockSize, 0, stream&gt;&gt;&gt;(d_<xsl:value-of select="xmml:name"/>s); <!-- Twin Karmakharm Change - Bug found, need to reset the actual message array and not the swap array -->
 	gpuErrchkLaunch();
 	</xsl:if></xsl:if></xsl:for-each>
 	</xsl:if></xsl:if>
-	
-	
+
+
 	<xsl:if test="../../gpu:type='continuous'"><xsl:if test="gpu:reallocate='true'">
-	//IF CONTINUOUS AGENT CAN REALLOCATE (process dead agents) THEN RESET AGENT SWAPS	
-	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, reset_<xsl:value-of select="../../xmml:name"/>_scan_input, no_sm, state_list_size); 
+	//IF CONTINUOUS AGENT CAN REALLOCATE (process dead agents) THEN RESET AGENT SWAPS
+	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, reset_<xsl:value-of select="../../xmml:name"/>_scan_input, no_sm, state_list_size);
 	gridSize = (state_list_size + blockSize - 1) / blockSize;
 	reset_<xsl:value-of select="../../xmml:name"/>_scan_input&lt;&lt;&lt;gridSize, blockSize, 0, stream&gt;&gt;&gt;(d_<xsl:value-of select="../../xmml:name"/>s);
 	gpuErrchkLaunch();
 	</xsl:if></xsl:if>
-	
+
 	//MAIN XMACHINE FUNCTION CALL (<xsl:value-of select="xmml:name"/>)
 	//Reallocate   : <xsl:choose><xsl:when test="gpu:reallocate='true'">true</xsl:when><xsl:otherwise>false</xsl:otherwise></xsl:choose>
 	//Input        : <xsl:value-of select="xmml:inputs/gpu:input/xmml:messageName"/>
@@ -958,7 +956,7 @@ void <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>
 		<xsl:if test="xmml:outputs/gpu:output">, d_<xsl:value-of select="xmml:outputs/gpu:output/xmml:messageName"/>s<xsl:if test="xmml:outputs/gpu:output/xmml:type='optional_message'">_swap</xsl:if></xsl:if>
 		<xsl:if test="gpu:RNG='true'">, d_rand48</xsl:if>);
 	gpuErrchkLaunch();
-	
+
 	<xsl:if test="xmml:inputs/gpu:input"><xsl:variable name="messageName" select="xmml:inputs/gpu:input/xmml:messageName"/>
 	//UNBIND MESSAGE INPUT VARIABLE TEXTURES
 	<xsl:for-each select="../../../../xmml:messages/gpu:message[xmml:name=$messageName]">
@@ -983,14 +981,14 @@ void <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>
 	<!-- end bug fix -->
     thrust::exclusive_scan(thrust::cuda::par.on(stream), thrust::device_pointer_cast(d_<xsl:value-of select="xmml:name"/>s_swap->_scan_input), thrust::device_pointer_cast(d_<xsl:value-of select="xmml:name"/>s_swap->_scan_input) + h_xmachine_memory_<xsl:value-of select="$xagentName"/>_count, thrust::device_pointer_cast(d_<xsl:value-of select="xmml:name"/>s_swap->_position));
 	//Scatter
-	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, scatter_optional_<xsl:value-of select="xmml:name"/>_messages, no_sm, state_list_size); 
+	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, scatter_optional_<xsl:value-of select="xmml:name"/>_messages, no_sm, state_list_size);
 	gridSize = (state_list_size + blockSize - 1) / blockSize;
 	scatter_optional_<xsl:value-of select="xmml:name"/>_messages&lt;&lt;&lt;gridSize, blockSize, 0, stream&gt;&gt;&gt;(d_<xsl:value-of select="xmml:name"/>s, d_<xsl:value-of select="xmml:name"/>s_swap);
 	gpuErrchkLaunch();
 	</xsl:if></xsl:if>
 	</xsl:for-each></xsl:if>
 	</xsl:if>
-	
+
 	<xsl:if test="xmml:outputs/gpu:output"><xsl:variable name="messageName" select="xmml:outputs/gpu:output/xmml:messageName"/><xsl:variable name="outputType" select="xmml:outputs/gpu:output/gpu:type"/><xsl:variable name="xagentName" select="../../xmml:name"/>
 	//UPDATE MESSAGE COUNTS FOR CONTINUOUS AGENTS WITH NON PARTITIONED MESSAGE OUTPUT <xsl:if test="../../gpu:type='continuous'">
 	<xsl:for-each select="../../../../xmml:messages/gpu:message[xmml:name=$messageName]">
@@ -1007,24 +1005,24 @@ void <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>
     </xsl:if><xsl:if test="$outputType='single_message'">
 	h_message_<xsl:value-of select="xmml:name"/>_count += h_xmachine_memory_<xsl:value-of select="$xagentName"/>_count;
 	</xsl:if>//Copy count to device
-	gpuErrchk( cudaMemcpyToSymbol( d_message_<xsl:value-of select="xmml:name"/>_count, &amp;h_message_<xsl:value-of select="xmml:name"/>_count, sizeof(int)));	
+	gpuErrchk( cudaMemcpyToSymbol( d_message_<xsl:value-of select="xmml:name"/>_count, &amp;h_message_<xsl:value-of select="xmml:name"/>_count, sizeof(int)));
 	</xsl:if>
 	</xsl:for-each>
 	</xsl:if>
 	</xsl:if>
-	
+
 	<xsl:if test="xmml:xagentOutputs/gpu:xagentOutput">
 	<xsl:variable name="xagent_output" select="xmml:xagentOutputs/gpu:xagentOutput/xmml:xagentName"/><xsl:if test="../../../gpu:xagent[xmml:name=$xagent_output]/gpu:type='continuous'">
     //COPY ANY AGENT COUNT BEFORE <xsl:value-of select="../../xmml:name"/> AGENTS ARE KILLED (needed for scatter)
 	int <xsl:value-of select="../../xmml:name"/>s_pre_death_count = h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count;
 	</xsl:if>
 	</xsl:if>
-	
+
 	<xsl:if test="../../gpu:type='continuous'"><xsl:if test="gpu:reallocate='true'">
-	//FOR CONTINUOUS AGENTS WITH REALLOCATION REMOVE POSSIBLE DEAD AGENTS	
+	//FOR CONTINUOUS AGENTS WITH REALLOCATION REMOVE POSSIBLE DEAD AGENTS
     thrust::exclusive_scan(thrust::cuda::par.on(stream), thrust::device_pointer_cast(d_<xsl:value-of select="../../xmml:name"/>s->_scan_input), thrust::device_pointer_cast(d_<xsl:value-of select="../../xmml:name"/>s->_scan_input) + h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count, thrust::device_pointer_cast(d_<xsl:value-of select="../../xmml:name"/>s->_position));
 	//Scatter into swap
-	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, scatter_<xsl:value-of select="../../xmml:name"/>_Agents, no_sm, state_list_size); 
+	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, scatter_<xsl:value-of select="../../xmml:name"/>_Agents, no_sm, state_list_size);
 	gridSize = (state_list_size + blockSize - 1) / blockSize;
 	scatter_<xsl:value-of select="../../xmml:name"/>_Agents&lt;&lt;&lt;gridSize, blockSize, 0, stream&gt;&gt;&gt;(d_<xsl:value-of select="../../xmml:name"/>s_swap, d_<xsl:value-of select="../../xmml:name"/>s, 0, h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count);
 	gpuErrchkLaunch();
@@ -1040,12 +1038,12 @@ void <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>
 	else
 		h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count = scan_last_sum;
 	//Copy count to device
-	gpuErrchk( cudaMemcpyToSymbol( d_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count, &amp;h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count, sizeof(int)));	
+	gpuErrchk( cudaMemcpyToSymbol( d_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count, &amp;h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count, sizeof(int)));
 	</xsl:if></xsl:if>
 
 	<xsl:if test="xmml:xagentOutputs/gpu:xagentOutput"><xsl:for-each select="xmml:xagentOutputs/gpu:xagentOutput">
 	<xsl:variable name="xagent_output" select="xmml:xagentName"/><xsl:if test="../../../../../gpu:xagent[xmml:name=$xagent_output]/gpu:type='continuous'">
-	//FOR <xsl:value-of select="xmml:xagentName"/> AGENT OUTPUT SCATTER AGENTS 
+	//FOR <xsl:value-of select="xmml:xagentName"/> AGENT OUTPUT SCATTER AGENTS
     thrust::exclusive_scan(thrust::cuda::par.on(stream), thrust::device_pointer_cast(d_<xsl:value-of select="xmml:xagentName"/>s_new->_scan_input), thrust::device_pointer_cast(d_<xsl:value-of select="xmml:xagentName"/>s_new->_scan_input) + <xsl:value-of select="../../../../xmml:name"/>s_pre_death_count, thrust::device_pointer_cast(d_<xsl:value-of select="xmml:xagentName"/>s_new->_position));
 	//reset agent count
 	int <xsl:value-of select="xmml:xagentName"/>_after_birth_count;
@@ -1061,16 +1059,16 @@ void <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>
 		exit(EXIT_FAILURE);
 	}
 	//Scatter into swap
-	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, scatter_<xsl:value-of select="xmml:xagentName"/>_Agents, no_sm, state_list_size); 
+	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, scatter_<xsl:value-of select="xmml:xagentName"/>_Agents, no_sm, state_list_size);
 	gridSize = (state_list_size + blockSize - 1) / blockSize;
 	scatter_<xsl:value-of select="xmml:xagentName"/>_Agents&lt;&lt;&lt;gridSize, blockSize, 0, stream&gt;&gt;&gt;(d_<xsl:value-of select="xmml:xagentName"/>s_<xsl:value-of select="xmml:state"/>, d_<xsl:value-of select="xmml:xagentName"/>s_new, h_xmachine_memory_<xsl:value-of select="xmml:xagentName"/>_<xsl:value-of select="xmml:state"/>_count, <xsl:value-of select="../../../../xmml:name"/>s_pre_death_count);
 	gpuErrchkLaunch();
 	//Copy count to device
 	h_xmachine_memory_<xsl:value-of select="xmml:xagentName"/>_<xsl:value-of select="xmml:state"/>_count = <xsl:value-of select="xmml:xagentName"/>_after_birth_count;
-	gpuErrchk( cudaMemcpyToSymbol( d_xmachine_memory_<xsl:value-of select="xmml:xagentName"/>_<xsl:value-of select="xmml:state"/>_count, &amp;h_xmachine_memory_<xsl:value-of select="xmml:xagentName"/>_<xsl:value-of select="xmml:state"/>_count, sizeof(int)));	
+	gpuErrchk( cudaMemcpyToSymbol( d_xmachine_memory_<xsl:value-of select="xmml:xagentName"/>_<xsl:value-of select="xmml:state"/>_count, &amp;h_xmachine_memory_<xsl:value-of select="xmml:xagentName"/>_<xsl:value-of select="xmml:state"/>_count, sizeof(int)));
 	</xsl:if></xsl:for-each>
 	</xsl:if>
-	
+
 	<xsl:if test="xmml:outputs/gpu:output"><xsl:variable name="messageName" select="xmml:outputs/gpu:output/xmml:messageName"/>
 	<xsl:for-each select="../../../../xmml:messages/gpu:message[xmml:name=$messageName]">
 	<xsl:if test="gpu:partitioningSpatial">
@@ -1080,23 +1078,23 @@ void <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>
     if (h_message_<xsl:value-of select="xmml:name"/>_count > 0){
 #ifdef FAST_ATOMIC_SORTING
       //USE ATOMICS TO BUILD PARTITION BOUNDARY
-	  cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, hist_<xsl:value-of select="xmml:name"/>_messages, no_sm, h_message_<xsl:value-of select="xmml:name"/>_count); 
+	  cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, hist_<xsl:value-of select="xmml:name"/>_messages, no_sm, h_message_<xsl:value-of select="xmml:name"/>_count);
 	  gridSize = (h_message_<xsl:value-of select="xmml:name"/>_count + blockSize - 1) / blockSize;
 	  hist_<xsl:value-of select="xmml:name"/>_messages&lt;&lt;&lt;gridSize, blockSize, 0, stream&gt;&gt;&gt;(d_xmachine_message_<xsl:value-of select="xmml:name"/>_local_bin_index, d_xmachine_message_<xsl:value-of select="xmml:name"/>_unsorted_index, d_<xsl:value-of select="xmml:name"/>_partition_matrix->end_or_count, d_<xsl:value-of select="xmml:name"/>s, h_message_<xsl:value-of select="xmml:name"/>_count);
 	  gpuErrchkLaunch();
-	
+
 	  thrust::device_ptr&lt;int&gt; ptr_count = thrust::device_pointer_cast(d_<xsl:value-of select="xmml:name"/>_partition_matrix->end_or_count);
 	  thrust::device_ptr&lt;int&gt; ptr_index = thrust::device_pointer_cast(d_<xsl:value-of select="xmml:name"/>_partition_matrix->start);
 	  thrust::exclusive_scan(thrust::cuda::par.on(stream), ptr_count, ptr_count + xmachine_message_<xsl:value-of select="xmml:name"/>_grid_size, ptr_index); // scan
-	
-	  cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, reorder_<xsl:value-of select="xmml:name"/>_messages, no_sm, h_message_<xsl:value-of select="xmml:name"/>_count); 
-	  gridSize = (h_message_<xsl:value-of select="xmml:name"/>_count + blockSize - 1) / blockSize; 	// Round up according to array size 
+
+	  cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, reorder_<xsl:value-of select="xmml:name"/>_messages, no_sm, h_message_<xsl:value-of select="xmml:name"/>_count);
+	  gridSize = (h_message_<xsl:value-of select="xmml:name"/>_count + blockSize - 1) / blockSize; 	// Round up according to array size
 	  reorder_<xsl:value-of select="xmml:name"/>_messages &lt;&lt;&lt;gridSize, blockSize, 0, stream&gt;&gt;&gt;(d_xmachine_message_<xsl:value-of select="xmml:name"/>_local_bin_index, d_xmachine_message_<xsl:value-of select="xmml:name"/>_unsorted_index, d_<xsl:value-of select="xmml:name"/>_partition_matrix->start, d_<xsl:value-of select="xmml:name"/>s, d_<xsl:value-of select="xmml:name"/>s_swap, h_message_<xsl:value-of select="xmml:name"/>_count);
 	  gpuErrchkLaunch();
 #else
 	  //HASH, SORT, REORDER AND BUILD PMB FOR SPATIAL PARTITIONING MESSAGE OUTPUTS
 	  //Get message hash values for sorting
-	  cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, hash_<xsl:value-of select="xmml:name"/>_messages, no_sm, h_message_<xsl:value-of select="xmml:name"/>_count); 
+	  cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, hash_<xsl:value-of select="xmml:name"/>_messages, no_sm, h_message_<xsl:value-of select="xmml:name"/>_count);
 	  gridSize = (h_message_<xsl:value-of select="xmml:name"/>_count + blockSize - 1) / blockSize;
 	  hash_<xsl:value-of select="xmml:name"/>_messages&lt;&lt;&lt;gridSize, blockSize, 0, stream&gt;&gt;&gt;(d_xmachine_message_<xsl:value-of select="xmml:name"/>_keys, d_xmachine_message_<xsl:value-of select="xmml:name"/>_values, d_<xsl:value-of select="xmml:name"/>s);
 	  gpuErrchkLaunch();
@@ -1105,7 +1103,7 @@ void <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>
 	  gpuErrchkLaunch();
 	  //reorder and build pcb
 	  gpuErrchk(cudaMemset(d_<xsl:value-of select="xmml:name"/>_partition_matrix->start, 0xffffffff, xmachine_message_<xsl:value-of select="xmml:name"/>_grid_size* sizeof(int)));
-	  cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, reorder_<xsl:value-of select="xmml:name"/>_messages, reorder_messages_sm_size, h_message_<xsl:value-of select="xmml:name"/>_count); 
+	  cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, reorder_<xsl:value-of select="xmml:name"/>_messages, reorder_messages_sm_size, h_message_<xsl:value-of select="xmml:name"/>_count);
 	  gridSize = (h_message_<xsl:value-of select="xmml:name"/>_count + blockSize - 1) / blockSize;
 	  int reorder_sm_size = reorder_messages_sm_size(blockSize);
 	  reorder_<xsl:value-of select="xmml:name"/>_messages&lt;&lt;&lt;gridSize, blockSize, reorder_sm_size, stream&gt;&gt;&gt;(d_xmachine_message_<xsl:value-of select="xmml:name"/>_keys, d_xmachine_message_<xsl:value-of select="xmml:name"/>_values, d_<xsl:value-of select="xmml:name"/>_partition_matrix, d_<xsl:value-of select="xmml:name"/>s, d_<xsl:value-of select="xmml:name"/>s_swap);
@@ -1119,7 +1117,7 @@ void <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>
 	</xsl:if>
 	</xsl:for-each>
 	</xsl:if>
-	
+
 	//************************ MOVE AGENTS TO NEXT STATE ****************************
     <xsl:choose>
     <xsl:when test="../../gpu:type='continuous'">
@@ -1129,13 +1127,13 @@ void <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>
 		exit(EXIT_FAILURE);
 	}
 	//append agents to next state list
-	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, append_<xsl:value-of select="../../xmml:name"/>_Agents, no_sm, state_list_size); 
+	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, append_<xsl:value-of select="../../xmml:name"/>_Agents, no_sm, state_list_size);
 	gridSize = (state_list_size + blockSize - 1) / blockSize;
 	append_<xsl:value-of select="../../xmml:name"/>_Agents&lt;&lt;&lt;gridSize, blockSize, 0, stream&gt;&gt;&gt;(d_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:nextState"/>, d_<xsl:value-of select="../../xmml:name"/>s, h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:nextState"/>_count, h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count);
 	gpuErrchkLaunch();
 	//update new state agent size
 	h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:nextState"/>_count += h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count;
-	gpuErrchk( cudaMemcpyToSymbol( d_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:nextState"/>_count, &amp;h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:nextState"/>_count, sizeof(int)));	
+	gpuErrchk( cudaMemcpyToSymbol( d_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:nextState"/>_count, &amp;h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:nextState"/>_count, sizeof(int)));
 	</xsl:when>
     <xsl:when test="../../gpu:type='discrete'">
     //currentState maps to working list
@@ -1144,22 +1142,22 @@ void <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>
 	d_<xsl:value-of select="../../xmml:name"/>s = <xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:currentState"/>_temp;
     //set current state count
 	h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:currentState"/>_count = h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count;
-	gpuErrchk( cudaMemcpyToSymbol( d_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:currentState"/>_count, &amp;h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:currentState"/>_count, sizeof(int)));	
+	gpuErrchk( cudaMemcpyToSymbol( d_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:currentState"/>_count, &amp;h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:currentState"/>_count, sizeof(int)));
 	</xsl:when>
   </xsl:choose>
-	
+
 }
 
 
 </xsl:for-each>
-    
 
-<xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent/xmml:states/gpu:state"> 
+
+<xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent/xmml:states/gpu:state">
 extern void reset_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_count()
 {
     h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_count = 0;
 }
 </xsl:for-each>
-    
+
 </xsl:template>
 </xsl:stylesheet>

--- a/FLAMEGPU/templates/simulation.xslt
+++ b/FLAMEGPU/templates/simulation.xslt
@@ -897,7 +897,7 @@ void <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>
 	<xsl:if test="../../gpu:type='discrete'"><xsl:for-each select="../../../../xmml:messages/gpu:message[xmml:name=$messageName]"><xsl:if test="gpu:partitioningDiscrete">
 	//check that the range is not greater than the square of the block size. If so then there will be too many uncoalesded reads
 	if (h_message_<xsl:value-of select="xmml:name"/>_range > (int)blockSize){
-		printf("ERROR: Message range is greater than the thread block size. Increase thread block size or reduce the range!\n");
+		printf("ERROR: Message range is greater than the thread block size. Increase thread block size or reduce the range!");
 		exit(EXIT_FAILURE);
 	}
 	</xsl:if></xsl:for-each></xsl:if></xsl:if>

--- a/FLAMEGPU/templates/visualisation.xslt
+++ b/FLAMEGPU/templates/visualisation.xslt
@@ -313,7 +313,7 @@ int initGL()
 	glewInit();
 	if (! glewIsSupported( "GL_VERSION_2_0 " 
 		"GL_ARB_pixel_buffer_object")) {
-		fprintf( stderr, "ERROR: Support for necessary OpenGL extensions missing.\n");
+		fprintf( stderr, "ERROR: Support for necessary OpenGL extensions missing.");
 		fflush( stderr);
 		return 1;
 	}


### PR DESCRIPTION
Removed requirement for initial states xml file. Changed `readInitialStates` so that it initialises all variables to the default value and then returns if no initial states file is found while printing a warning instead of terminating the program. 

When there's 0 agent count, the agent function belonging to the agent does not run.

Command line arguments stay the same for backward compatibility. 

