### PR TITLE
Update functions.xslt message list parsing for partitioned messaging

### DIFF
--- a/FLAMEGPU/templates/functions.xslt
+++ b/FLAMEGPU/templates/functions.xslt
@@ -43,10 +43,20 @@ __FLAME_GPU_FUNC__ int <xsl:value-of select="xmml:name"/>(xmachine_memory_<xsl:v
 <xsl:if test="gpu:RNG='true'">, RNG_rand48* rand48</xsl:if>){
 
     <xsl:if test="xmml:inputs/gpu:input">
-    /* 
-    //Template for input message iteration
     <xsl:variable name="messagename" select="xmml:inputs/gpu:input/xmml:messageName"/>
-    xmachine_message_<xsl:value-of select="xmml:inputs/gpu:input/xmml:messageName"/>* current_message = get_first_<xsl:value-of select="$messagename"/>_message(<xsl:value-of select="$messagename"/>_messages<xsl:if test="gpu:partitioningSpatial">, partition_matrix</xsl:if>);
+        <xsl:for-each select="../../../../xmml:messages/gpu:message[xmml:name=$messagename]">
+    /*<xsl:if test="gpu:partitioningDiscrete">
+    // Index of discrete cell
+    int agent_x = 0;
+    int agent_y = 0;
+    </xsl:if><xsl:if test="gpu:partitioningSpatial">
+    // Position within space
+    float agent_x = 0.0;
+    float agent_y = 0.0;
+    float agent_z = 0.0;
+    </xsl:if>
+    //Template for input message iteration
+    xmachine_message_<xsl:value-of select="xmml:inputs/gpu:input/xmml:messageName"/>* current_message = get_first_<xsl:value-of select="$messagename"/>_message(<xsl:value-of select="$messagename"/>_messages<xsl:if test="gpu:partitioningSpatial">, partition_matrix, agent_x, agent_y, agent_z</xsl:if><xsl:if test="gpu:partitioningDiscrete">, agent_x, agent_y</xsl:if>);
     while (current_message)
     {
         //INSERT MESSAGE PROCESSING CODE HERE
@@ -54,9 +64,10 @@ __FLAME_GPU_FUNC__ int <xsl:value-of select="xmml:name"/>(xmachine_memory_<xsl:v
         current_message = get_next_<xsl:value-of select="$messagename"/>_message(current_message, <xsl:value-of select="$messagename"/>_messages<xsl:if test="gpu:partitioningSpatial">, partition_matrix</xsl:if>);
     }
     */
-    </xsl:if><xsl:if test="xmml:outputs/gpu:output">
+    </xsl:for-each></xsl:if><xsl:if test="xmml:outputs/gpu:output">
     /* 
-    //Template for message output function use <xsl:variable name="messagename" select="xmml:outputs/gpu:output/xmml:messageName"/>
+    //Template for message output function
+    <xsl:variable name="messagename" select="xmml:outputs/gpu:output/ xmml:messageName"/>
     <xsl:for-each select="../../../../xmml:messages/gpu:message[xmml:name=$messagename]/xmml:variables/gpu:variable">
     <xsl:value-of select="xmml:type"/><xsl:text> </xsl:text><xsl:value-of select="xmml:name"/> = 0;
     </xsl:for-each>


### PR DESCRIPTION
suggests correct function prototypes in functions.xslt for spatially partitioned and discrete partitioned messages - i.e `agent_x`, `agent_y`, `agent_z`, and passes the PBM for spatial messages.

Closes #119 