### PR TITLE
Rc1.5/empty xml fix

### DIFF
--- a/FLAMEGPU/templates/io.xslt
+++ b/FLAMEGPU/templates/io.xslt
@@ -251,11 +251,20 @@ void readInitialStates(char* inputpath, <xsl:for-each select="gpu:xmodel/xmml:xa
     </xsl:for-each>
     
 	/* Read file until end of xml */
+    size_t bytesRead = 0;
     i = 0;
 	while(reading==1)
 	{
 		/* Get the next char from the file */
 		c = (char)fgetc(file);
+
+        // Check if we reached the end of the file.
+        if(c == EOF){
+            // Break out of the loop. This allows for empty files(which may or may not be)
+            break;
+        }
+        // Increment byte counter.
+        bytesRead++;
 		
 		/* If the end of a tag */
 		if(c == '&gt;')
@@ -389,6 +398,12 @@ void readInitialStates(char* inputpath, <xsl:for-each select="gpu:xmodel/xmml:xa
 			i++;
 		}
 	}
+    // If no bytes were read, raise a warning.
+    if(bytesRead == 0){
+        fprintf(stdout, "Warning: %s is an empty file\n", inputpath);
+        fflush(stdout);
+    }
+
 	/* Close the file */
 	fclose(file);
 }

--- a/FLAMEGPU/templates/io.xslt
+++ b/FLAMEGPU/templates/io.xslt
@@ -166,9 +166,9 @@ void readInitialStates(char* inputpath, <xsl:for-each select="gpu:xmodel/xmml:xa
     int in_env_<xsl:value-of select="xmml:name"/>;
     </xsl:for-each>
     
-
-	/* for continuous agents: set agent count to zero */<xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent"><xsl:if test="gpu:type='continuous'">	
-	*h_xmachine_memory_<xsl:value-of select="xmml:name"/>_count = 0;</xsl:if></xsl:for-each>
+    <!-- initialise the population of all agent types to 0, to avoid launch failures -->
+	/* set agent count to zero */<xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent"><!--<xsl:if test="gpu:type='continuous'">-->
+	*h_xmachine_memory_<xsl:value-of select="xmml:name"/>_count = 0;<!--</xsl:if>--></xsl:for-each>
 	
 	/* Variables for initial state data */<xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent/xmml:memory/gpu:variable"><xsl:choose><xsl:when test="xmml:arrayLength"><xsl:text>
     </xsl:text><xsl:value-of select="xmml:type"/><xsl:text> </xsl:text><xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>[<xsl:value-of select="xmml:arrayLength"/>];</xsl:when><xsl:otherwise><xsl:text>

--- a/FLAMEGPU/templates/simulation.xslt
+++ b/FLAMEGPU/templates/simulation.xslt
@@ -881,12 +881,14 @@ void <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>
 
 	
 	//CHECK THE CURRENT STATE LIST COUNT IS NOT EQUAL TO 0
-	<xsl:if test="../../gpu:type='continuous'">
+	<!-- This check has been removed so that we do net get unspecified launch failures when a population of 0 discrete agents is used.
+	Alternatively this should be expanded to elseif, with an error message and a graceful exit of the simulator.
+	<xsl:if test="../../gpu:type='continuous'"> -->
 	if (h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:currentState"/>_count == 0)
 	{
 		return;
 	}
-	</xsl:if>
+	<!-- </xsl:if> -->
 	
 	//SET SM size to 0 and save state list size for occupancy calculations
 	sm_size = SM_START;


### PR DESCRIPTION
Fixes the issues of crashses / segfaults for empty initial states files.

+ Raises a warning if the file is completely empty (0 bytes read)
+ Adds a check for `discrete` agent population sizes
    + Avoids an `invalid launch configuration` issue when an discrete agent state has `0` population. This check was previously only applied to `continuous` agents.
    + This is likely better than not allowing simulations with empty statelists to execute, as agents may be created from `step` functions in `1.5`.

Closes #148 
