### PR TITLE
Rc1.5/no init

### DIFF
--- a/FLAMEGPU/templates/io.xslt
+++ b/FLAMEGPU/templates/io.xslt
@@ -28,11 +28,6 @@
 #include &lt;cmath&gt;
 #include &lt;limits.h&gt;
 
-// Only check directory under linux. it is not an issue on windows. 
-#if !defined(_MSC_VER)
-#include &lt;sys/stat.h&gt;
-#endif
-
 // include header
 #include "header.h"
 
@@ -227,33 +222,24 @@ void readInitialStates(char* inputpath, <xsl:for-each select="gpu:xmodel/xmml:xa
     </xsl:otherwise></xsl:choose>
     </xsl:for-each>
     
-	/* Open config file to read-only */
-	// Under linux, use Stat to check if the inputpath is a directory or not.
-    #if !defined(_MSC_VER)
-    struct stat st = {0};
-    if(!stat(inputpath, &amp;st)){
-        bool inputpathIsDirectory = S_ISDIR(st.st_mode);
-        if(inputpathIsDirectory){
-            printf("Error: input path `%s` is a directory\n", inputpath);
-            return;
-        }
-    } else {
-        printf("Error checking input path. Aborting.\n");
-        exit(EXIT_FAILURE);
+    // If no input path was specified, issue a message and return.
+    if(inputpath[0] == '\0'){
+        printf("No initial states file specified. Using default values.\n");
+        return;
     }
-    #endif
-	// Attempt to open the non-directory input path
+    
+    // Otherwise an input path was specified, and we have previously checked that it is (was) not a directory. 
+    
+	// Attempt to open the non directory path as read only.
 	file = fopen(inputpath, "r");
-
-	
-    /* If inputfile is empty or not found then we initialise only */
-    if(inputpath == NULL || file == nullptr)
+    
+    // If the file could not be opened, issue a message and return.
+    if(file == nullptr)
     {
-      printf("Initial states file not specifed or does not exist, parameters are initialised to default values\n");
+      printf("Could not open input file %s. Continuing with default values\n", inputpath);
       return;
     }
-
-	/* Read file until end of xml */
+    // Otherwise we can iterate the file until the end of XML is reached.
     size_t bytesRead = 0;
     i = 0;
 	while(reading==1)

--- a/FLAMEGPU/templates/io.xslt
+++ b/FLAMEGPU/templates/io.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:xmml="http://www.dcs.shef.ac.uk/~paul/XMML"
                 xmlns:gpu="http://www.dcs.shef.ac.uk/~paul/XMMLGPU">
 <xsl:output method="text" version="1.0" encoding="UTF-8" indent="yes" />
@@ -90,7 +90,7 @@ void saveIterationData(char* outputpath, int iteration_number, <xsl:for-each sel
 	//Device to host memory transfer
 	<xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent/xmml:states/gpu:state">
 	cudaStatus = cudaMemcpy( h_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:name"/>, d_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:name"/>, sizeof(xmachine_memory_<xsl:value-of select="../../xmml:name"/>_list), cudaMemcpyDeviceToHost);
-	if (cudaStatus != cudaSuccess) 
+	if (cudaStatus != cudaSuccess)
 	{
 		fprintf(stderr,"Error Copying <xsl:value-of select="../../xmml:name"/> Agent <xsl:value-of select="xmml:name"/> State Memory from GPU: %s\n", cudaGetErrorString(cudaStatus));
 		exit(cudaStatus);
@@ -173,38 +173,15 @@ void readInitialStates(char* inputpath, <xsl:for-each select="gpu:xmodel/xmml:xa
 	/* Variables for initial state data */<xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent/xmml:memory/gpu:variable"><xsl:choose><xsl:when test="xmml:arrayLength"><xsl:text>
     </xsl:text><xsl:value-of select="xmml:type"/><xsl:text> </xsl:text><xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>[<xsl:value-of select="xmml:arrayLength"/>];</xsl:when><xsl:otherwise><xsl:text>
 	</xsl:text><xsl:value-of select="xmml:type"/><xsl:text> </xsl:text><xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>;</xsl:otherwise></xsl:choose></xsl:for-each>
-    
+
     /* Variables for environment variables */
     <xsl:for-each select="gpu:xmodel/gpu:environment/gpu:constants/gpu:variable"><xsl:choose><xsl:when test="xmml:arrayLength">
     <xsl:value-of select="xmml:type"/> env_<xsl:value-of select="xmml:name"/>[<xsl:value-of select="xmml:arrayLength"/>];
     </xsl:when><xsl:otherwise>
-    <xsl:value-of select="xmml:type"/> env_<xsl:value-of select="xmml:name"/>;   
+    <xsl:value-of select="xmml:type"/> env_<xsl:value-of select="xmml:name"/>;
     </xsl:otherwise></xsl:choose></xsl:for-each>
-	
-	/* Open config file to read-only */
-	// Under linux, use Stat to check if the inputpath is a directory or not.
-    #if !defined(_MSC_VER)
-    struct stat st = {0};
-    if(!stat(inputpath, &amp;st)){
-        bool inputpathIsDirectory = S_ISDIR(st.st_mode);
-        if(inputpathIsDirectory){
-            printf("Error: input path `%s` is a directory\n", inputpath);
-            exit(EXIT_FAILURE);
-        }
-    } else {
-        printf("Error checking input path. Aborting.\n");
-        exit(EXIT_FAILURE);
-    }
-    #endif
-	// Attempt to open the non-directory input path
-	file = fopen(inputpath, "r");
-	// If the input path does not exist, exit failure.
-	if(file==nullptr)
-	{
-		printf("Error opening initial states\n");
-		exit(EXIT_FAILURE);
-	}
-	
+
+
 	/* Initialise variables */<xsl:if test="gpu:xmodel/gpu:environment/gpu:constants/gpu:variable/xmml:defaultValue">
     initEnvVars();</xsl:if>
     agent_maximum.x = 0;
@@ -250,6 +227,32 @@ void readInitialStates(char* inputpath, <xsl:for-each select="gpu:xmodel/xmml:xa
     </xsl:otherwise></xsl:choose>
     </xsl:for-each>
     
+	/* Open config file to read-only */
+	// Under linux, use Stat to check if the inputpath is a directory or not.
+    #if !defined(_MSC_VER)
+    struct stat st = {0};
+    if(!stat(inputpath, &amp;st)){
+        bool inputpathIsDirectory = S_ISDIR(st.st_mode);
+        if(inputpathIsDirectory){
+            printf("Error: input path `%s` is a directory\n", inputpath);
+            return;
+        }
+    } else {
+        printf("Error checking input path. Aborting.\n");
+        exit(EXIT_FAILURE);
+    }
+    #endif
+	// Attempt to open the non-directory input path
+	file = fopen(inputpath, "r");
+
+	
+    /* If inputfile is empty or not found then we initialise only */
+    if(inputpath == NULL || file == nullptr)
+    {
+      printf("Initial states file not specifed or does not exist, parameters are initialised to default values\n");
+      return;
+    }
+
 	/* Read file until end of xml */
     size_t bytesRead = 0;
     i = 0;
@@ -265,13 +268,13 @@ void readInitialStates(char* inputpath, <xsl:for-each select="gpu:xmodel/xmml:xa
         }
         // Increment byte counter.
         bytesRead++;
-		
+
 		/* If the end of a tag */
 		if(c == '&gt;')
 		{
 			/* Place 0 at end of buffer to make chars a string */
 			buffer[i] = 0;
-			
+
 			if(strcmp(buffer, "states") == 0) reading = 1;
 			if(strcmp(buffer, "/states") == 0) reading = 0;
 			if(strcmp(buffer, "itno") == 0) in_itno = 1;
@@ -285,7 +288,7 @@ void readInitialStates(char* inputpath, <xsl:for-each select="gpu:xmodel/xmml:xa
 			{
 				<xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent">
 				<xsl:if test="position()!=1">else </xsl:if>if(strcmp(agentname, "<xsl:value-of select="xmml:name"/>") == 0)
-				{		
+				{
 					if (*h_xmachine_memory_<xsl:value-of select="xmml:name"/>_count > xmachine_memory_<xsl:value-of select="xmml:name"/>_MAX){
 						printf("ERROR: MAX Buffer size (%i) for agent <xsl:value-of select="xmml:name"/> exceeded whilst reading data\n", xmachine_memory_<xsl:value-of select="xmml:name"/>_MAX);
 						// Close the file and stop reading
@@ -294,7 +297,7 @@ void readInitialStates(char* inputpath, <xsl:for-each select="gpu:xmodel/xmml:xa
 					}
                     <xsl:for-each select="xmml:memory/gpu:variable"><xsl:choose><xsl:when test="xmml:arrayLength">
                     for (int k=0;k&lt;<xsl:value-of select="xmml:arrayLength"/>;k++){
-                        h_<xsl:value-of select="../../xmml:name"/>s-><xsl:value-of select="xmml:name"/>[(k*xmachine_memory_<xsl:value-of select="../../xmml:name"/>_MAX)+(*h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count)] = <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>[k];    
+                        h_<xsl:value-of select="../../xmml:name"/>s-><xsl:value-of select="xmml:name"/>[(k*xmachine_memory_<xsl:value-of select="../../xmml:name"/>_MAX)+(*h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count)] = <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>[k];
                     }</xsl:when><xsl:otherwise>
 					h_<xsl:value-of select="../../xmml:name"/>s-><xsl:value-of select="xmml:name"/>[*h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_count] = <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>;</xsl:otherwise></xsl:choose>
                     <xsl:if test="xmml:name='x'">//Check maximum x value
@@ -321,21 +324,21 @@ void readInitialStates(char* inputpath, <xsl:for-each select="gpu:xmodel/xmml:xa
                     if(agent_minimum.z &gt; <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>)
                         agent_minimum.z = (float)<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>;
                     </xsl:if></xsl:for-each>
-					(*h_xmachine_memory_<xsl:value-of select="xmml:name"/>_count) ++;	
+					(*h_xmachine_memory_<xsl:value-of select="xmml:name"/>_count) ++;
 				}
 				</xsl:for-each>else
 				{
 					printf("Warning: agent name undefined - '%s'\n", agentname);
 				}
-				
 
-				
+
+
 				/* Reset xagent variables */<xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent/xmml:memory/gpu:variable"><xsl:choose><xsl:when test="xmml:arrayLength">
                 for (i=0;i&lt;<xsl:value-of select="xmml:arrayLength"/>;i++){
                     <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>[i] = <xsl:choose><xsl:when test="xmml:defaultValue"><xsl:value-of select="xmml:defaultValue"/></xsl:when><xsl:otherwise>0</xsl:otherwise></xsl:choose>;
                 }</xsl:when><xsl:otherwise><xsl:text>
                 </xsl:text><xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/> = <xsl:choose><xsl:when test="xmml:defaultValue"><xsl:value-of select="xmml:defaultValue"/></xsl:when><xsl:otherwise>0</xsl:otherwise></xsl:choose>;</xsl:otherwise></xsl:choose></xsl:for-each>
-                
+
                 in_xagent = 0;
 			}
 			<xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent/xmml:memory/gpu:variable">if(strcmp(buffer, "<xsl:value-of select="xmml:name"/>") == 0) in_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/> = 1;
@@ -345,7 +348,7 @@ void readInitialStates(char* inputpath, <xsl:for-each select="gpu:xmodel/xmml:xa
             <xsl:for-each select="gpu:xmodel/gpu:environment/gpu:constants/gpu:variable">if(strcmp(buffer, "<xsl:value-of select="xmml:name"/>") == 0) in_env_<xsl:value-of select="xmml:name"/> = 1;
             if(strcmp(buffer, "/<xsl:value-of select="xmml:name"/>") == 0) in_env_<xsl:value-of select="xmml:name"/> = 0;
 			</xsl:for-each>
-    
+
 			/* End of tag and reset buffer */
 			in_tag = 0;
 			i = 0;
@@ -357,12 +360,12 @@ void readInitialStates(char* inputpath, <xsl:for-each select="gpu:xmodel/xmml:xa
 			buffer[i] = 0;
 			/* Flag in tag */
 			in_tag = 1;
-			
+
 			if(in_itno) *itno = atoi(buffer);
 			if(in_name) strcpy(agentname, buffer);
 			else if (in_xagent)
 			{
-				<xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent/xmml:memory/gpu:variable">if(in_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>){ 
+				<xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent/xmml:memory/gpu:variable">if(in_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>){
                     <xsl:choose><xsl:when test="xmml:arrayLength">read<xsl:choose><xsl:when test="xmml:type='int'">Int</xsl:when><xsl:otherwise>Float</xsl:otherwise></xsl:choose>ArrayInput(buffer, <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>, <xsl:value-of select="xmml:arrayLength"/>);    </xsl:when>
                     <xsl:otherwise><xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/> = (<xsl:value-of select="xmml:type"/>) ato<xsl:choose><xsl:when test="xmml:type='int'">i</xsl:when><xsl:otherwise>f</xsl:otherwise></xsl:choose>(buffer);    </xsl:otherwise></xsl:choose>
                 }
@@ -371,17 +374,17 @@ void readInitialStates(char* inputpath, <xsl:for-each select="gpu:xmodel/xmml:xa
             else if (in_env){
                 <xsl:for-each select="gpu:xmodel/gpu:environment/gpu:constants/gpu:variable">if(in_env_<xsl:value-of select="xmml:name"/>){<xsl:choose><xsl:when test="xmml:arrayLength">
                     //array input
-                    read<xsl:choose><xsl:when test="xmml:type='int'">Int</xsl:when><xsl:otherwise>Float</xsl:otherwise></xsl:choose>ArrayInput(buffer, env_<xsl:value-of select="xmml:name"/>, <xsl:value-of select="xmml:arrayLength"/>); 
+                    read<xsl:choose><xsl:when test="xmml:type='int'">Int</xsl:when><xsl:otherwise>Float</xsl:otherwise></xsl:choose>ArrayInput(buffer, env_<xsl:value-of select="xmml:name"/>, <xsl:value-of select="xmml:arrayLength"/>);
                     set_<xsl:value-of select="xmml:name"/>(env_<xsl:value-of select="xmml:name"/>);</xsl:when>
                     <xsl:otherwise>
                     //scalar value input
                     env_<xsl:value-of select="xmml:name"/> = (<xsl:value-of select="xmml:type"/>) ato<xsl:choose><xsl:when test="xmml:type='int'">i</xsl:when><xsl:otherwise>f</xsl:otherwise></xsl:choose>(buffer);
                     set_<xsl:value-of select="xmml:name"/>(&amp;env_<xsl:value-of select="xmml:name"/>);
-                    </xsl:otherwise></xsl:choose>  
+                    </xsl:otherwise></xsl:choose>
                 }
                 </xsl:for-each>
             }
-			
+
 			/* Reset buffer */
 			i = 0;
 		}

--- a/FLAMEGPU/templates/main.xslt
+++ b/FLAMEGPU/templates/main.xslt
@@ -24,6 +24,7 @@
 #include &lt;stdio.h&gt;
 #include &lt;string.h&gt;
 #include &lt;sys/stat.h&gt;
+#include &lt;errno.h&gt;
 #ifdef VISUALISATION
 #include &lt;GL/glew.h&gt;
 #include &lt;GL/glut.h&gt;
@@ -153,8 +154,8 @@ bool getPathProperties(char * path, bool * isFile, bool * isDir) {
 	// If stat was successfull
 	if (statResult == 0) {
 		// Update return values indicating if the path is a file or a directory.
-		*isDir = (statBuf.st_mode &amp; _S_IFDIR) != 0;
-		*isFile = (statBuf.st_mode &amp; _S_IFREG) != 0;
+		*isDir = (statBuf.st_mode &amp; S_IFDIR) != 0;
+		*isFile = (statBuf.st_mode &amp; S_IFREG) != 0;
 		fileExists = *isDir || *isFile;
 	} 
 	// Otherwise if stat did report an errr.

--- a/FLAMEGPU/templates/main.xslt
+++ b/FLAMEGPU/templates/main.xslt
@@ -22,6 +22,8 @@
 */
 #include &lt;cuda_runtime.h&gt;
 #include &lt;stdio.h&gt;
+#include &lt;string.h&gt;
+#include &lt;sys/stat.h&gt;
 #ifdef VISUALISATION
 #include &lt;GL/glew.h&gt;
 #include &lt;GL/glut.h&gt;
@@ -41,54 +43,198 @@ char outputpath[1000];         /**&lt; Output path char buffer*/
  * @param argv	main argument values
  * @return true if usage is correct, otherwise false
  */
-int checkUsage( int argc, char** argv){
+int checkUsage(int argc, char** argv) {
+	// Initalise return value.
+	int retval = true;
+
+	// Get the EXE name.
+	char * executable = nullptr;
+	size_t i = 0;
+	size_t last = 0;
+	while (argv[0][i] != '\0')
+	{
+		/* For windows directories */
+		if (argv[0][i] == '\\') last = i + 1;
+		/* For unix directories */
+		if (argv[0][i] == '/') last = i + 1;
+		i++;
+	}
+
+	size_t substrLen = strlen(argv[0]) - last;
+	executable = (char*)malloc(substrLen + 1);
+	if (executable != nullptr) {
+		executable[substrLen] = '\0';
+		strncpy(executable, argv[0] + last, substrLen);
+	}
+
+
 	//Check usage
 #ifdef VISUALISATION
 	printf("FLAMEGPU Visualisation mode\n");
 	if(argc &lt; 2)
 	{
-		printf("Usage: main [XML model data] [Optional CUDA device ID]\n");
-		return false;
+		printf("\nusage: %s input_path [cuda_device_id]\n", executable != nullptr ? executable : "main");
+		printf("\n");
+		printf("required arguments:\n");
+		printf("  input_path           Path to initial states XML file OR path to output XML directory\n");
+		printf("\n");
+		printf("options arguments:\n");
+		printf("  cuda_device_id       CUDA device ID to be used. Default is 0.\n");
+		// Set the appropriate return value
+		retval = false;
 	}
 #else
 	printf("FLAMEGPU Console mode\n");
 	if(argc &lt; 3)
 	{
-		printf("Usage: main [XML model data] [Iterations] [Optional CUDA device ID] [Optional XML Output Override]\n");
-		return false;
+		printf("\nusage: %s input_path num_iterations [cuda_device_id] [XML_output_override]\n", executable != nullptr ? executable : "main");
+		printf("\n");
+		printf("required arguments:\n");
+		printf("  input_path           Path to initial states XML file OR path to output XML directory\n");
+		printf("  num_iterations       Number of simulation iterations\n");
+		printf("\n");
+		printf("options arguments:\n");
+		printf("  cuda_device_id       CUDA device ID to be used. Default is 0.\n");
+		printf("  XML_output_override  Flag indicating if iteration data should be output as XML\n");
+		printf("                       0 = false, 1 = true. Default %d\n", OUTPUT_TO_XML);
+		// Set the appropriate return value
+		retval = false;
 	}
 #endif
-	return true;
+
+	// Free malloced memory
+	free(executable);
+	executable = nullptr;
+	// return the appropriate code.
+	return retval;
 }
 
-const char* getOutputDir(){
-  return outputpath;
+
+/** parentDirectoryOfPath
+* Function which given a path removes the last segment, copying into a pre-defined buffer.
+* @param parent pre allocated buffer for the shoretened path
+* @param path input path to be shortented
+*/
+void parentDirectoryOfPath(char * parent, char * path) {
+	int i = 0;
+	int lastd = -1;
+	while (path[i] != '\0')
+	{
+		/* For windows directories */
+		if (path[i] == '\\') lastd = i;
+		/* For unix directories */
+		if (path[i] == '/') lastd = i;
+		i++;
+	}
+	strcpy(parent, path);
+	//parent[lastd + 1] = '\0';
+	// Replace the traling slash, as files and directories cannot have the same name.
+	parent[lastd + 1] = '\0';
 }
 
+/** getPathProperties
+* Function to get information about a filepath, if it exists, is a file or is a directory
+* @param path path to be checked
+* @param isFile returned boolean indicating if the path points to a file.
+* @param isDir return boolean indicating if the path points to a directory.
+* @return boolean indicating if the path exists.
+*/
+bool getPathProperties(char * path, bool * isFile, bool * isDir) {
+	bool fileExists = false;
+	// Initialse bools to false.
+	*isFile = false;
+	*isDir = false;
+
+	// Buffer for stat output.
+	struct stat statBuf {0};
+	// Use stat to query the path information.
+	int statResult = stat(path, &amp;statBuf);
+
+	// If stat was successfull
+	if (statResult == 0) {
+		// Update return values indicating if the path is a file or a directory.
+		*isDir = (statBuf.st_mode &amp; _S_IFDIR) != 0;
+		*isFile = (statBuf.st_mode &amp; _S_IFREG) != 0;
+		fileExists = *isDir || *isFile;
+	} 
+	// Otherwise if stat did report an errr.
+	else {
+		// If the file does not exist, set this and continue.
+		if (errno == ENOENT) {
+			fileExists = false;
+		}
+		// For any other errors, we should abort.
+		else {
+			fprintf(stderr, "Error: An unknown error occured while processing file infomration.\n");
+			fflush(stdout);
+			exit(EXIT_FAILURE);
+		}
+	}
+	// Return if the file exists or not.
+	return fileExists;
+}
 
 /** setFilePaths
  * Function to set global variables for the input XML file and its directory location
  *@param input input path of model xml file
  */
 void setFilePaths(char* input){
-	//Copy input file
-	strcpy(inputfile, input);
-	printf("Initial states: %s\n", inputfile);
+	
 
-	//Calculate the output path from the path of the input file
-	int i = 0;
-	int lastd = -1;
-	while(inputfile[i] != '\0')
-	{
-		/* For windows directories */
-		if(inputfile[i] == '\\') lastd=i;
-		/* For unix directories */
-		if(inputfile[i] == '/') lastd=i;
-		i++;
+	// Get infomration about the inputpath file.
+	bool inputIsFile = false;
+	bool inputIsDir = false;
+	bool inputExists = getPathProperties(input, &amp;inputIsFile, &amp;inputIsDir);
+
+	// If input exists:
+	if (inputExists) {
+		// If it is a file
+		if (inputIsFile) {
+			//Copy input file, and proceed as normal.
+			strcpy(inputfile, input);
+			// We must get the parent directory as the output directory.
+			parentDirectoryOfPath(outputpath, inputfile);
+		}
+		// Otherwise it is a directory
+		else {
+			// We do not have an input file., but use this as the directory.
+			inputfile[0] = '\0';
+			strcpy(outputpath, input);
+		}
 	}
-	strcpy(outputpath, inputfile);
-	outputpath[lastd+1] = '\0';
-	printf("Output dir: %s\n", outputpath);
+	// Otherwise if the input file does not exist
+	else {
+		// The input path is empty.
+		inputfile[0] = '\0';
+		// Try to find a parent directory.
+		parentDirectoryOfPath(outputpath, input);
+
+		// Check if the parent directory exists.
+		bool dirIsFile = false;
+		bool dirIsDir = false;
+		bool dirExists = getPathProperties(outputpath, &amp;dirIsFile, &amp;dirIsDir);
+
+		// If the dir exists
+		if (dirExists) {
+			// IF the dir is not a directory, it is a file. Abort.
+			if (!dirIsDir || dirIsFile) {
+				printf("Error: outputpath `%s` exists, but it is not a directory.\n", outputpath);
+				exit(EXIT_FAILURE);
+			}
+			else {
+				// Otherwise the parent directory exists and is a directory.
+				printf("Warning: `%s` does not exist using parent directory for output.\n", input);
+			}
+		}
+		else {
+			// If the directory does not exist, use the working directory.
+			printf("Warning: Parent directory `%s` does not exist. Using current working directory for output.\n", outputpath);
+			outputpath[0] = '\0';
+		}
+	}
+
+	printf("Initial states: %s\n", inputfile[0] != '\0' ? inputfile : "(none)");
+	printf("Output dir: %s\n", outputpath[0] != '\0' ? outputpath : "(cwd)");
 }
 
 
@@ -103,7 +249,7 @@ bool getOutputXML(int argc, char**argv){
 	// If console mode is set and we have the right number of arguments, use the relevant index.
 	if (argc &gt;= 5){
 		// Return the value from the argument.
-		return (bool)atoi(argv[4]);
+		return atoi(argv[4]) != 0;
 	} else {
 		// Return the default value.
 		return (bool) OUTPUT_TO_XML;


### PR DESCRIPTION
Closes #84.

+ Usage instructions updated to reflect recent changes
+ `inputpath` is now set to `""` and not used if it does not exist.
+ Variables are initialised correctly even if no input file specified
+ `outputpath` is either:
    + Passed in from command line if `inputpath` is a directory
    + Parent of `inputpath` if `inputpath` is a file (which does or does not exist)
    + The current working directory if the parent of `inputpath` does not exist.