### PR TITLE
Add missing getOutputDir function

### DIFF
--- a/FLAMEGPU/templates/main.xslt
+++ b/FLAMEGPU/templates/main.xslt
@@ -110,6 +110,14 @@ int checkUsage(int argc, char** argv) {
 	return retval;
 }
 
+/** getOutputDir
+ * Function which gets the global char array contianign the path for output
+ * @return char array containing relative path to output locaiton
+ */
+const char* getOutputDir(){
+    return outputpath;
+}
+
 
 /** parentDirectoryOfPath
 * Function which given a path removes the last segment, copying into a pre-defined buffer.


### PR DESCRIPTION
Re-adds the `getOutputDir` functions I accidentally removed whilst working on `main.xslt`