### PR TITLE
Remove MonteCarlo projects from Makefile as no corresponding dirs exist.

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -40,7 +40,7 @@ help:
 TARGET_ARCH ?= $(shell uname -m)
 
 # Project folders that contain FLAMEGPU examples
-PROJECTS ?= $(shell find Boids_BruteForce Boids_Partitioning CirclesBruteForce_double CirclesBruteForce_float CirclesPartitioning_double CirclesPartitioning_float GameOfLife Keratinocyte MonteCarlo_BATCH MonteCarlo_MSMPR PedestrianLOD PedestrianNavigation StableMarriage Sugarscape Template -name Makefile)
+PROJECTS ?= $(shell find Boids_BruteForce Boids_Partitioning CirclesBruteForce_double CirclesBruteForce_float CirclesPartitioning_double CirclesPartitioning_float GameOfLife Keratinocyte PedestrianLOD PedestrianNavigation StableMarriage Sugarscape Template -name Makefile)
 
 %.ph_build :
 	+@$(MAKE) -C $(dir $*) $(MAKECMDGOALS)


### PR DESCRIPTION
Can now run 'make' from within 'examples' without seeing warnings re this.