### PR TITLE
Update makefiles to suggest using -B and depend on MAKEFILE_LIST

### DIFF
--- a/examples/Analytics/Makefile
+++ b/examples/Analytics/Makefile
@@ -1,6 +1,6 @@
 ################################################################################
 #
-# FLAME GPU Makefile for CUDA 7.5 and above
+# FLAME GPU Makefile
 #
 # Copyright 2017 University of Sheffield.  All rights reserved.
 #

--- a/examples/Boids_BruteForce/Makefile
+++ b/examples/Boids_BruteForce/Makefile
@@ -1,6 +1,6 @@
 ################################################################################
 #
-# FLAME GPU Makefile for CUDA 7.5 and above
+# FLAME GPU Makefile 
 #
 # Copyright 2017 University of Sheffield.  All rights reserved.
 #

--- a/examples/Boids_Partitioning/Makefile
+++ b/examples/Boids_Partitioning/Makefile
@@ -1,6 +1,6 @@
 ################################################################################
 #
-# FLAME GPU Makefile for CUDA 7.5 and above
+# FLAME GPU Makefile 
 #
 # Copyright 2017 University of Sheffield.  All rights reserved.
 #

--- a/examples/Boids_PartitioningVecTypes/Makefile
+++ b/examples/Boids_PartitioningVecTypes/Makefile
@@ -1,6 +1,6 @@
 ################################################################################
 #
-# FLAME GPU Makefile for CUDA 7.5 and above
+# FLAME GPU Makefile 
 #
 # Copyright 2017 University of Sheffield.  All rights reserved.
 #

--- a/examples/CirclesBruteForce_double/Makefile
+++ b/examples/CirclesBruteForce_double/Makefile
@@ -1,6 +1,6 @@
 ################################################################################
 #
-# FLAME GPU Makefile for CUDA 7.5 and above
+# FLAME GPU Makefile 
 #
 # Copyright 2017 University of Sheffield.  All rights reserved.
 #

--- a/examples/CirclesBruteForce_float/Makefile
+++ b/examples/CirclesBruteForce_float/Makefile
@@ -1,6 +1,6 @@
 ################################################################################
 #
-# FLAME GPU Makefile for CUDA 7.5 and above
+# FLAME GPU Makefile 
 #
 # Copyright 2017 University of Sheffield.  All rights reserved.
 #

--- a/examples/CirclesPartitioning_double/Makefile
+++ b/examples/CirclesPartitioning_double/Makefile
@@ -1,6 +1,6 @@
 ################################################################################
 #
-# FLAME GPU Makefile for CUDA 7.5 and above
+# FLAME GPU Makefile 
 #
 # Copyright 2017 University of Sheffield.  All rights reserved.
 #

--- a/examples/CirclesPartitioning_float/Makefile
+++ b/examples/CirclesPartitioning_float/Makefile
@@ -1,6 +1,6 @@
 ################################################################################
 #
-# FLAME GPU Makefile for CUDA 7.5 and above
+# FLAME GPU Makefile 
 #
 # Copyright 2017 University of Sheffield.  All rights reserved.
 #

--- a/examples/EmptyExample/Makefile
+++ b/examples/EmptyExample/Makefile
@@ -1,6 +1,6 @@
 ################################################################################
 #
-# FLAME GPU Makefile for CUDA 7.5 and above
+# FLAME GPU Makefile 
 #
 # Copyright 2017 University of Sheffield.  All rights reserved.
 #

--- a/examples/GameOfLife/Makefile
+++ b/examples/GameOfLife/Makefile
@@ -1,6 +1,6 @@
 ################################################################################
 #
-# FLAME GPU Makefile for CUDA 7.5 and above
+# FLAME GPU Makefile 
 #
 # Copyright 2017 University of Sheffield.  All rights reserved.
 #

--- a/examples/HostAgentCreation/Makefile
+++ b/examples/HostAgentCreation/Makefile
@@ -1,6 +1,6 @@
 ################################################################################
 #
-# FLAME GPU Makefile for CUDA 7.5 and above
+# FLAME GPU Makefile 
 #
 # Copyright 2017 University of Sheffield.  All rights reserved.
 #

--- a/examples/Keratinocyte/Makefile
+++ b/examples/Keratinocyte/Makefile
@@ -1,6 +1,6 @@
 ################################################################################
 #
-# FLAME GPU Makefile for CUDA 7.5 and above
+# FLAME GPU Makefile 
 #
 # Copyright 2017 University of Sheffield.  All rights reserved.
 #

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -45,7 +45,7 @@ help:
 	@echo "                     1 : Debug"
 	@echo "                     I.e. 'make all debug=1'"
 	@echo "    SMS=<arg>   -> Builds target for the specified CUDA architectures"
-	@echo "                     I.e. 'make all SMS=60 61'"
+	@echo "                     I.e. 'make all SMS=\"60 61\"'"
 	@echo "************************************************************************"
 
 

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,7 +1,6 @@
 ################################################################################
 #
-# FLAME GPU Makefile for CUDA 7.5 and above
-#
+# FLAME GPU Makefile for batch compilation of all examples 
 # Copyright 2017 University of Sheffield.  All rights reserved.
 #
 # Authors : Dr Mozhgan Kabiri Chimeh, Dr Paul Richmond
@@ -38,6 +37,8 @@ help:
 	@echo "    clobber       -> Deletes all generated files including executables"
 	@echo ""
 	@echo "  Arguments":
+	@echo "    On first modifcation of values using this method ensure that files are"
+	@echo "    rebuilt by using 'make'."
 	@echo ""
 	@echo "    debug=<arg> -> Builds target in 'Release' or 'Debug' mode"
 	@echo "                     0 : Release (Default)"
@@ -45,8 +46,6 @@ help:
 	@echo "                     I.e. 'make all debug=1'"
 	@echo "    SMS=<arg>   -> Builds target for the specified CUDA architectures"
 	@echo "                     I.e. 'make all SMS=60 61'"
-	@echo "                     Defaults to: '$(SMS)'"
-	@echo "                     Note: 'make clean' is required prior to using new values"
 	@echo "************************************************************************"
 
 

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -38,7 +38,7 @@ help:
 	@echo ""
 	@echo "  Arguments":
 	@echo "    On first modifcation of values using this method ensure that files are"
-	@echo "    rebuilt by using 'make'."
+	@echo "    rebuilt by using 'make -B <target> <args>'."
 	@echo ""
 	@echo "    debug=<arg> -> Builds target in 'Release' or 'Debug' mode"
 	@echo "                     0 : Release (Default)"

--- a/examples/MonteCarlo_BATCH/Makefile
+++ b/examples/MonteCarlo_BATCH/Makefile
@@ -1,6 +1,6 @@
 ################################################################################
 #
-# FLAME GPU Makefile for CUDA 7.5 and above
+# FLAME GPU Makefile 
 #
 # Copyright 2017 University of Sheffield.  All rights reserved.
 #

--- a/examples/MonteCarlo_MSMPR/Makefile
+++ b/examples/MonteCarlo_MSMPR/Makefile
@@ -1,6 +1,6 @@
 ################################################################################
 #
-# FLAME GPU Makefile for CUDA 7.5 and above
+# FLAME GPU Makefile 
 #
 # Copyright 2017 University of Sheffield.  All rights reserved.
 #

--- a/examples/PedestrianLOD/Makefile
+++ b/examples/PedestrianLOD/Makefile
@@ -1,6 +1,6 @@
 ################################################################################
 #
-# FLAME GPU Makefile for CUDA 7.5 and above
+# FLAME GPU Makefile 
 #
 # Copyright 2017 University of Sheffield.  All rights reserved.
 #

--- a/examples/PedestrianNavigation/Makefile
+++ b/examples/PedestrianNavigation/Makefile
@@ -1,6 +1,6 @@
 ################################################################################
 #
-# FLAME GPU Makefile for CUDA 7.5 and above
+# FLAME GPU Makefile 
 #
 # Copyright 2017 University of Sheffield.  All rights reserved.
 #

--- a/examples/StableMarriage/Makefile
+++ b/examples/StableMarriage/Makefile
@@ -1,6 +1,6 @@
 ################################################################################
 #
-# FLAME GPU Makefile for CUDA 7.5 and above
+# FLAME GPU Makefile 
 #
 # Copyright 2017 University of Sheffield.  All rights reserved.
 #

--- a/examples/Sugarscape/Makefile
+++ b/examples/Sugarscape/Makefile
@@ -1,6 +1,6 @@
 ################################################################################
 #
-# FLAME GPU Makefile for CUDA 7.5 and above
+# FLAME GPU Makefile 
 #
 # Copyright 2017 University of Sheffield.  All rights reserved.
 #

--- a/tools/common.mk
+++ b/tools/common.mk
@@ -110,6 +110,13 @@ else
 SMS ?= $(DEFAULT_SMS_CUDA_6)
 endif
 
+# Incase SMS is comma separated, split the commas.
+comma:= ,
+empty:=
+space:= $(empty) $(empty)
+TMP_SMS:= $(subst $(comma),$(space),$(SMS))
+override SMS = $(TMP_SMS)
+
 # Flags used for compilation.
 # NVCC compiler flags
 NVCCFLAGS   := -m64 -lineinfo

--- a/tools/common.mk
+++ b/tools/common.mk
@@ -101,6 +101,14 @@ NVCC_GE_9_0 = $(shell [ $(NVCC_MAJOR) -ge 9 ] && echo true)
 NVCC_GE_8_0 = $(shell [ $(NVCC_MAJOR) -ge 8 ] && echo true)
 
 
+# If SM has been specified in place of SMS, set the value appropriately.
+ifneq ($(SM),)
+ifeq ($(SMS),)
+SMS = $(SM)
+$(warning "Warning - 'SMS' should be specified rather than 'SM'. Using '$(SM)'.")
+endif
+endif
+
 # For the appropriate CUDA version, assign default SMS if required.
 ifeq ($(NVCC_GE_9_0),true)
 SMS ?= $(DEFAULT_SMS_CUDA_9)

--- a/tools/common.mk
+++ b/tools/common.mk
@@ -450,6 +450,6 @@ help:
 	@echo "                   1 : Debug"
 	@echo "                   I.e. 'make console debug=1'"
 	@echo "   SMS=<arg>     Builds target for the specified CUDA architectures"
-	@echo "                   I.e. 'make console SMS=60 61'"
+	@echo "                   I.e. 'make console SMS=\"60 61\"'"
 	@echo "                   Defaults to: '$(SMS)'"
 	@echo "************************************************************************"

--- a/tools/common.mk
+++ b/tools/common.mk
@@ -401,15 +401,15 @@ $(TARGET_CONSOLE): $(CONSOLE_DEPENDANCIES)
 
 # Clean object files, but do not regenerate xslt. `|| true` is used to support the case where dirs do not exist.
 clean:
-	find $(EXAMPLE_BUILD_DIR)/ -name '*$(OBJ_EXT)' -delete || true
-	find $(EXAMPLE_BUILD_DIR)/ -name '*.cu$(OBJ_EXT)' -delete || true
+	@find $(EXAMPLE_BUILD_DIR)/ -name '*$(OBJ_EXT)' -delete 2> /dev/null || true
+	@find $(EXAMPLE_BUILD_DIR)/ -name '*.cu$(OBJ_EXT)' -delete 2> /dev/null || true
 
 # Clobber all temporary files, including dynamic files and the target executable. `|| true` is used to support the case where dirs do not exist.
 clobber: clean
-	find $(SRC_DYNAMIC)/ -name '*.c' -delete || true
-	find $(SRC_DYNAMIC)/ -name '*.cu' -delete || true
-	find $(SRC_DYNAMIC)/ -name '*.h' -delete || true
-	find $(BIN_DIR)/ -name '$(EXAMPLE)$(BIN_EXT)' -delete || true
+	@find $(SRC_DYNAMIC)/ -name '*.c' -delete 2> /dev/null || true
+	@find $(SRC_DYNAMIC)/ -name '*.cu' -delete 2> /dev/null || true
+	@find $(SRC_DYNAMIC)/ -name '*.h' -delete 2> /dev/null || true
+	@find $(BIN_DIR)/ -name '$(EXAMPLE)$(BIN_EXT)' -delete 2> /dev/null || true
 
 # Create any required directories.
 makedirs:

--- a/tools/common.mk
+++ b/tools/common.mk
@@ -1,5 +1,5 @@
 ################################################################################
-# FLAME GPU common Makefile rules for CUDA 7.5 and above
+# FLAME GPU common Makefile rules
 #
 # Copyright 2017 University of Sheffield.  All rights reserved.
 #
@@ -288,7 +288,7 @@ endif
 xslt: validate $(XSLT_OUTPUT_FILES)
 
 # Create functions.c prototypes as a differently named file, to avoid overwriting user code.
-functions.c: validate $(XSLT_FUNCTIONS_C)
+functions.c: validate $(XSLT_FUNCTIONS_C) $(MAKEFILE_LIST)
 
 # Create the console version of this application, inlcuding directory creation and validation of the XML Model
 console: makedirs validate $(TARGET_CONSOLE)
@@ -299,7 +299,7 @@ visualisation: makedirs validate $(TARGET_VISUALISATION)
 endif
 
 # Rule to create header.h from XSLT. Depends upon both header.xslt and the XML file, so if either is changed a re-build will occur.
-$(SRC_DYNAMIC)/%.h: $(TEMPLATES_DIR)/%.xslt $(XML_MODEL_FILE)
+$(SRC_DYNAMIC)/%.h: $(TEMPLATES_DIR)/%.xslt $(XML_MODEL_FILE)  $(MAKEFILE_LIST)
 # Error if XSLTPROC is not available
 ifndef XSLTPROC
 	$(error "xsltproc is not available, please install xlstproc")
@@ -320,7 +320,7 @@ else
 endif
 
 # Rule to create *.cu files in the dynamic folder, as requested by build dependencies.
-$(SRC_DYNAMIC)/%.cu: $(TEMPLATES_DIR)/%.xslt $(XML_MODEL_FILE)
+$(SRC_DYNAMIC)/%.cu: $(TEMPLATES_DIR)/%.xslt $(XML_MODEL_FILE) $(MAKEFILE_LIST)
 # Error if XSLTPROC is not available
 ifndef XSLTPROC
 	$(error "xsltproc is not available, please install xlstproc")
@@ -341,7 +341,7 @@ else
 endif
 
 # Rule to create functsion.c file in the dynamic folder.
-$(SRC_DYNAMIC)/%.c: $(TEMPLATES_DIR)/%.xslt $(XML_MODEL_FILE)
+$(SRC_DYNAMIC)/%.c: $(TEMPLATES_DIR)/%.xslt $(XML_MODEL_FILE) $(MAKEFILE_LIST)
 # Error if XSLTPROC is not available
 ifndef XSLTPROC
 	$(error "xsltproc is not available, please install xlstproc")
@@ -363,30 +363,30 @@ endif
 
 # Explicit rules for object files in the dynamic folder.
 # Explicit rules are used (rather than generic) as the dependancis are non-trivial (currently)
-$(BUILD_DIR)/io.cu$(OBJ_EXT): $(SRC_DYNAMIC)/io.cu $(SRC_DYNAMIC)/header.h
+$(BUILD_DIR)/io.cu$(OBJ_EXT): $(SRC_DYNAMIC)/io.cu $(SRC_DYNAMIC)/header.h $(MAKEFILE_LIST)
 	$(EXEC) $(NVCC) $(CONSOLE_INCLUDES) $(ALL_CCFLAGS) $(GENCODE_FLAGS) -o $@ -c $<
-$(BUILD_DIR)/simulation.cu$(OBJ_EXT): $(SRC_DYNAMIC)/simulation.cu $(SRC_DYNAMIC)/FLAMEGPU_kernals.cu $(FUNCTIONS_FILES) $(SRC_DYNAMIC)/header.h
+$(BUILD_DIR)/simulation.cu$(OBJ_EXT): $(SRC_DYNAMIC)/simulation.cu $(SRC_DYNAMIC)/FLAMEGPU_kernals.cu $(FUNCTIONS_FILES) $(SRC_DYNAMIC)/header.h $(MAKEFILE_LIST)
 	$(EXEC) $(NVCC) $(CONSOLE_INCLUDES) $(ALL_CCFLAGS) $(GENCODE_FLAGS) -o $@ -c $<
-$(BUILD_DIR)/main_console.cu$(OBJ_EXT): $(SRC_DYNAMIC)/main.cu $(SRC_DYNAMIC)/header.h
+$(BUILD_DIR)/main_console.cu$(OBJ_EXT): $(SRC_DYNAMIC)/main.cu $(SRC_DYNAMIC)/header.h $(MAKEFILE_LIST)
 	$(EXEC) $(NVCC) $(CONSOLE_INCLUDES) $(ALL_CCFLAGS) $(GENCODE_FLAGS) -o $@ -c $<
 
 ifeq ($(HAS_VISUALISATION), 1)
 # Visualisation specific dynamic file rules.
-$(BUILD_DIR)/main_visualisation.cu$(OBJ_EXT): $(SRC_DYNAMIC)/main.cu $(SRC_DYNAMIC)/header.h
+$(BUILD_DIR)/main_visualisation.cu$(OBJ_EXT): $(SRC_DYNAMIC)/main.cu $(SRC_DYNAMIC)/header.h $(MAKEFILE_LIST)
 	$(EXEC) $(NVCC) $(CONSOLE_INCLUDES) $(VISUALISATION_INCLUDES) $(ALL_CCFLAGS) $(GENCODE_FLAGS) -o $@ -c -DVISUALISATION $<
 # Only build visualistion$(OBJ_EXT) if not a custom visuations
 ifeq ($(CUSTOM_VISUALISATION), 0)
-$(BUILD_DIR)/visualisation.cu$(OBJ_EXT): $(SRC_DYNAMIC)/visualisation.cu $(SRC_VISUALISATION)/visualisation.h $(SRC_DYNAMIC)/header.h
+$(BUILD_DIR)/visualisation.cu$(OBJ_EXT): $(SRC_DYNAMIC)/visualisation.cu $(SRC_VISUALISATION)/visualisation.h $(SRC_DYNAMIC)/header.h $(MAKEFILE_LIST)
 	$(EXEC) $(NVCC) $(CONSOLE_INCLUDES) $(VISUALISATION_INCLUDES) $(ALL_CCFLAGS) $(GENCODE_FLAGS) -o $@ -c -DVISUALISATION $<
 else
 # Rules for custom visualistion compilation of c files
-$(BUILD_DIR)/%$(OBJ_EXT): $(SRC_VISUALISATION)/%.c
+$(BUILD_DIR)/%$(OBJ_EXT): $(SRC_VISUALISATION)/%.c $(MAKEFILE_LIST)
 	$(EXEC) $(NVCC) $(CONSOLE_INCLUDES) $(VISUALISATION_INCLUDES) $(ALL_CCFLAGS) $(GENCODE_FLAGS) -o $@ -c -DVISUALISATION $<
 # Rules for custom visualistion compilation of cpp files
-$(BUILD_DIR)/%$(OBJ_EXT): $(SRC_VISUALISATION)/%.cpp
+$(BUILD_DIR)/%$(OBJ_EXT): $(SRC_VISUALISATION)/%.cpp $(MAKEFILE_LIST)
 	$(EXEC) $(NVCC) $(CONSOLE_INCLUDES) $(VISUALISATION_INCLUDES) $(ALL_CCFLAGS) $(GENCODE_FLAGS) -o $@ -c -DVISUALISATION $<
 # Rules for custom visualistion compilation of cu files
-$(BUILD_DIR)/%.cu$(OBJ_EXT): $(SRC_VISUALISATION)/%.cu
+$(BUILD_DIR)/%.cu$(OBJ_EXT): $(SRC_VISUALISATION)/%.cu $(MAKEFILE_LIST)
 	$(EXEC) $(NVCC) $(CONSOLE_INCLUDES) $(VISUALISATION_INCLUDES) $(ALL_CCFLAGS) $(GENCODE_FLAGS) -o $@ -c -DVISUALISATION $<
 endif
 
@@ -441,7 +441,9 @@ help:
 	@echo "   functions.c   Generates functions.c in the dynamic folder using xslt"
 	@echo "                   This file is for reference only. Not used in build."
 	@echo ""
-	@echo " Arguments:"
+	@echo "  Arguments":
+	@echo "    On first modifcation of values using this method ensure that files are"
+	@echo "    rebuilt by using 'make'."
 	@echo ""
 	@echo "   debug=<arg>   Builds target in 'Release' or 'Debug' mode"
 	@echo "                   0 : Release (Default)"
@@ -450,5 +452,4 @@ help:
 	@echo "   SMS=<arg>     Builds target for the specified CUDA architectures"
 	@echo "                   I.e. 'make console SMS=60 61'"
 	@echo "                   Defaults to: '$(SMS)'"
-	@echo "                   'make clean' is required prior to using new values"
 	@echo "************************************************************************"

--- a/tools/common.mk
+++ b/tools/common.mk
@@ -443,7 +443,7 @@ help:
 	@echo ""
 	@echo "  Arguments":
 	@echo "    On first modifcation of values using this method ensure that files are"
-	@echo "    rebuilt by using 'make'."
+	@echo "    rebuilt by using 'make -B <target> <args>'."
 	@echo ""
 	@echo "   debug=<arg>   Builds target in 'Release' or 'Debug' mode"
 	@echo "                   0 : Release (Default)"


### PR DESCRIPTION
If makefiles are changes, a rebuild is forced of all targets.
make help instructs the user that if variables are specified on the command line,
they should use -B on the first call with the new flags, to force a rebuild.

Closes #168