### PR TITLE
Fix return type mismatch causing build failure

### DIFF
--- a/FLAMEGPU/templates/FLAMEGPU_kernals.xslt
+++ b/FLAMEGPU/templates/FLAMEGPU_kernals.xslt
@@ -1151,7 +1151,7 @@ __device__ xmachine_message_<xsl:value-of select="xmml:name"/>* get_first_<xsl:v
 	}
 	else
 	{
-		return false;
+		return NULL;
 	}
 }
 
@@ -1172,7 +1172,7 @@ __device__ xmachine_message_<xsl:value-of select="xmml:name"/>* get_next_<xsl:va
 		return ((xmachine_message_<xsl:value-of select="xmml:name"/>*)&amp;message_share[message_index]);
 	}
 	else
-		return false;
+		return NULL;
 	
 }
 


### PR DESCRIPTION
These two functions return pointers and newer versions of CUDA will no longer accept `false` in this case:

```
dynamic/FLAMEGPU_kernals.cu(614): error: return value type does not match the function type
```

Fix this by returning NULL instead of false.