### PR TITLE
Rc1.5/boids rule2 fix

### DIFF
--- a/examples/Boids_BruteForce/src/model/functions.c
+++ b/examples/Boids_BruteForce/src/model/functions.c
@@ -85,14 +85,14 @@ __FLAME_GPU_FUNC__ int inputdata(xmachine_memory_Boid* xmemory, xmachine_message
 	glm::vec3 agent_position = glm::vec3(xmemory->x, xmemory->y, xmemory->z);
 	glm::vec3 agent_velocity = glm::vec3(xmemory->fx, xmemory->fy, xmemory->fz);
 
-	//Boids perceived center
-	glm::vec3 global_centre = glm::vec3(0.0f, 0.0f, 0.0f);
-	int global_centre_count = 0;
+	//Boids perceived centre
+	glm::vec3 perceived_centre = glm::vec3(0.0f, 0.0f, 0.0f);
+	int perceived_count = 0;
 
 	//Boids global velocity matching
 	glm::vec3 global_velocity = glm::vec3(0.0f, 0.0f, 0.0f);
 
-	//Boids short range avoidance center
+	//Boids short range avoidance centre
 	glm::vec3 collision_centre = glm::vec3(0.0f, 0.0f, 0.0f);
 	int collision_count = 0;
 
@@ -110,15 +110,15 @@ __FLAME_GPU_FUNC__ int inputdata(xmachine_memory_Boid* xmemory, xmachine_message
 			float separation = length(agent_position - message_position);
 			if (separation < (INTERACTION_RADIUS)){
 
-				//Update Percieved global center
-				global_centre += message_position;
-				global_centre_count += 1;
+				//Update Perceived centre
+				perceived_centre += message_position;
+				perceived_count += 1;
 
-				//Update global velocity matching
+				//Update perceived velocity matching
 				glm::vec3 message_velocity = glm::vec3(location_message->fx, location_message->fy, location_message->fz);
 				global_velocity += message_velocity;
 
-				//Update collision center
+				//Update collision centre
 				if (separation < (SEPARATION_RADIUS)){ //dependant on model size
 					collision_centre += message_position;
 					collision_count += 1;
@@ -138,18 +138,18 @@ __FLAME_GPU_FUNC__ int inputdata(xmachine_memory_Boid* xmemory, xmachine_message
 	glm::vec3 velocity_change = glm::vec3(0.0f, 0.0f, 0.0f);
 
 
-	//Rule 1) Steer towards perceived center of flock (Cohesion)
+	//Rule 1) Steer towards perceived centre of flock (Cohesion)
 	glm::vec3 steer_velocity = glm::vec3(0.0f, 0.0f, 0.0f);
-	if (global_centre_count >0){
-		global_centre /= global_centre_count;
-		steer_velocity = (global_centre - agent_position)* STEER_SCALE;
+	if (perceived_count >0){
+		perceived_centre /= perceived_count;
+		steer_velocity = (perceived_centre - agent_position) * STEER_SCALE;
 	}
 	velocity_change += steer_velocity; 
 
 	//Rule 2) Match neighbours speeds (Alignment)
 	glm::vec3 match_velocity = glm::vec3(0.0f, 0.0f, 0.0f);
 	if (collision_count > 0){
-		global_velocity /= global_centre_count;
+		global_velocity /= perceived_count;
 		match_velocity = global_velocity * MATCH_SCALE;
 	}
 	velocity_change += match_velocity; 
@@ -158,7 +158,7 @@ __FLAME_GPU_FUNC__ int inputdata(xmachine_memory_Boid* xmemory, xmachine_message
 	glm::vec3 avoid_velocity = glm::vec3(0.0f, 0.0f, 0.0f);
 	if (collision_count > 0){
 		collision_centre /= collision_count;
-		avoid_velocity = (agent_position - collision_centre)* COLLISION_SCALE;
+		avoid_velocity = (agent_position - collision_centre) * COLLISION_SCALE;
 	}
 	velocity_change += avoid_velocity; 
 

--- a/examples/Boids_BruteForce/src/model/functions.c
+++ b/examples/Boids_BruteForce/src/model/functions.c
@@ -138,7 +138,7 @@ __FLAME_GPU_FUNC__ int inputdata(xmachine_memory_Boid* xmemory, xmachine_message
 	glm::vec3 velocity_change = glm::vec3(0.0f, 0.0f, 0.0f);
 
 
-	//Rule 1) Steer towards perceived center of flock
+	//Rule 1) Steer towards perceived center of flock (Cohesion)
 	glm::vec3 steer_velocity = glm::vec3(0.0f, 0.0f, 0.0f);
 	if (global_centre_count >0){
 		global_centre /= global_centre_count;
@@ -146,15 +146,15 @@ __FLAME_GPU_FUNC__ int inputdata(xmachine_memory_Boid* xmemory, xmachine_message
 	}
 	velocity_change += steer_velocity; 
 
-	//Rule 2) Match neighbours speeds
+	//Rule 2) Match neighbours speeds (Alignment)
 	glm::vec3 match_velocity = glm::vec3(0.0f, 0.0f, 0.0f);
 	if (collision_count > 0){
-		global_velocity /= collision_count;
-		match_velocity = match_velocity* MATCH_SCALE;
+		global_velocity /= global_centre_count;
+		match_velocity = global_velocity * MATCH_SCALE;
 	}
 	velocity_change += match_velocity; 
 
-	//Rule 3) Avoid close range neighbours
+	//Rule 3) Avoid close range neighbours (Separation)
 	glm::vec3 avoid_velocity = glm::vec3(0.0f, 0.0f, 0.0f);
 	if (collision_count > 0){
 		collision_centre /= collision_count;

--- a/examples/Boids_Partitioning/src/model/functions.c
+++ b/examples/Boids_Partitioning/src/model/functions.c
@@ -137,7 +137,7 @@ __FLAME_GPU_FUNC__ int inputdata(xmachine_memory_Boid* xmemory, xmachine_message
 	glm::vec3 velocity_change = glm::vec3(0.0f, 0.0f, 0.0f);
 
 
-	//Rule 1) Steer towards perceived center of flock
+	//Rule 1) Steer towards perceived center of flock (Cohesion)
 	glm::vec3 steer_velocity = glm::vec3(0.0f, 0.0f, 0.0f);
 	if (global_centre_count >0){
 		global_centre /= global_centre_count;
@@ -145,15 +145,15 @@ __FLAME_GPU_FUNC__ int inputdata(xmachine_memory_Boid* xmemory, xmachine_message
 	}
 	velocity_change += steer_velocity; 
 
-	//Rule 2) Match neighbours speeds
+	//Rule 2) Match neighbours speeds (Alignment)
 	glm::vec3 match_velocity = glm::vec3(0.0f, 0.0f, 0.0f);
 	if (collision_count > 0){
-		global_velocity /= collision_count;
-		match_velocity = match_velocity* MATCH_SCALE;
+		global_velocity /= global_centre_count;
+		match_velocity = global_velocity * MATCH_SCALE;
 	}
 	velocity_change += match_velocity; 
 
-	//Rule 3) Avoid close range neighbours
+	//Rule 3) Avoid close range neighbours (Separation)
 	glm::vec3 avoid_velocity = glm::vec3(0.0f, 0.0f, 0.0f);
 	if (collision_count > 0){
 		collision_centre /= collision_count;

--- a/examples/Boids_Partitioning/src/model/functions.c
+++ b/examples/Boids_Partitioning/src/model/functions.c
@@ -84,14 +84,14 @@ __FLAME_GPU_FUNC__ int inputdata(xmachine_memory_Boid* xmemory, xmachine_message
 	glm::vec3 agent_position = glm::vec3(xmemory->x, xmemory->y, xmemory->z);
 	glm::vec3 agent_velocity = glm::vec3(xmemory->fx, xmemory->fy, xmemory->fz);
 
-	//Boids perceived center
-	glm::vec3 global_centre = glm::vec3(0.0f, 0.0f, 0.0f);
-	int global_centre_count = 0;
+	//Boids perceived centre
+	glm::vec3 perceived_centre = glm::vec3(0.0f, 0.0f, 0.0f);
+	int perceived_count = 0;
 
 	//Boids global velocity matching
 	glm::vec3 global_velocity = glm::vec3(0.0f, 0.0f, 0.0f);
 
-	//Boids short range avoidance center
+	//Boids short range avoidance centre
 	glm::vec3 collision_centre = glm::vec3(0.0f, 0.0f, 0.0f);
 	int collision_count = 0;
 
@@ -109,15 +109,15 @@ __FLAME_GPU_FUNC__ int inputdata(xmachine_memory_Boid* xmemory, xmachine_message
 			float separation = length(agent_position - message_position);
 			if (separation < (INTERACTION_RADIUS)){
 
-				//Update Percieved global center
-				global_centre += message_position;
-				global_centre_count += 1;
+				//Update perceived centre
+				perceived_centre += message_position;
+				perceived_count += 1;
 
-				//Update global velocity matching
+				//Update perceived velocity matching
 				glm::vec3 message_velocity = glm::vec3(location_message->fx, location_message->fy, location_message->fz);
 				global_velocity += message_velocity;
 
-				//Update collision center
+				//Update collision centre
 				if (separation < (SEPARATION_RADIUS)){ //dependant on model size
 					collision_centre += message_position;
 					collision_count += 1;
@@ -137,18 +137,18 @@ __FLAME_GPU_FUNC__ int inputdata(xmachine_memory_Boid* xmemory, xmachine_message
 	glm::vec3 velocity_change = glm::vec3(0.0f, 0.0f, 0.0f);
 
 
-	//Rule 1) Steer towards perceived center of flock (Cohesion)
+	//Rule 1) Steer towards perceived centre of flock (Cohesion)
 	glm::vec3 steer_velocity = glm::vec3(0.0f, 0.0f, 0.0f);
-	if (global_centre_count >0){
-		global_centre /= global_centre_count;
-		steer_velocity = (global_centre - agent_position)* STEER_SCALE;
+	if (perceived_count >0){
+		perceived_centre /= perceived_count;
+		steer_velocity = (perceived_centre - agent_position) * STEER_SCALE;
 	}
 	velocity_change += steer_velocity; 
 
 	//Rule 2) Match neighbours speeds (Alignment)
 	glm::vec3 match_velocity = glm::vec3(0.0f, 0.0f, 0.0f);
 	if (collision_count > 0){
-		global_velocity /= global_centre_count;
+		global_velocity /= perceived_count;
 		match_velocity = global_velocity * MATCH_SCALE;
 	}
 	velocity_change += match_velocity; 
@@ -157,7 +157,7 @@ __FLAME_GPU_FUNC__ int inputdata(xmachine_memory_Boid* xmemory, xmachine_message
 	glm::vec3 avoid_velocity = glm::vec3(0.0f, 0.0f, 0.0f);
 	if (collision_count > 0){
 		collision_centre /= collision_count;
-		avoid_velocity = (agent_position - collision_centre)* COLLISION_SCALE;
+		avoid_velocity = (agent_position - collision_centre) * COLLISION_SCALE;
 	}
 	velocity_change += avoid_velocity; 
 

--- a/examples/Boids_PartitioningVecTypes/src/model/functions.c
+++ b/examples/Boids_PartitioningVecTypes/src/model/functions.c
@@ -80,14 +80,14 @@ __FLAME_GPU_FUNC__ int outputdata(xmachine_memory_Boid* xmemory, xmachine_messag
 //Agent Output: 
 __FLAME_GPU_FUNC__ int inputdata(xmachine_memory_Boid* xmemory, xmachine_message_location_list* location_messages, xmachine_message_location_PBM* partition_matrix) 
 {
-	//Boids perceived center
-	fvec3 global_centre = fvec3(0.0f, 0.0f, 0.0f);
-	int global_centre_count = 0;
+	//Boids perceived centre
+	fvec3 perceived_centre = fvec3(0.0f, 0.0f, 0.0f);
+	int perceived_count = 0;
 
-	//Boids global velocity matching
-	fvec3 global_velocity = fvec3(0.0f, 0.0f, 0.0f);
+	//Boids perceived velocity matching
+	fvec3 perceived_velocity = fvec3(0.0f, 0.0f, 0.0f);
 
-	//Boids short range avoidance center
+	//Boids short range avoidance centre
 	fvec3 collision_centre = fvec3(0.0f, 0.0f, 0.0f);
 	int collision_count = 0;
 
@@ -106,13 +106,12 @@ __FLAME_GPU_FUNC__ int inputdata(xmachine_memory_Boid* xmemory, xmachine_message
 			float separation = length(xmemory->position - message_position);
 			if (separation < (INTERACTION_RADIUS)){
 
-				//Update Perceived global centre
+				//Update perceived centre
+				perceived_centre += message_position;
+				perceived_count += 1;
 
-				global_centre += message_position;
-				global_centre_count += 1;
-
-				//Update global velocity matching
-				global_velocity += message_velocity;
+				//Update perceived velocity matching
+				perceived_velocity += message_velocity;
 
 				//Update collision centre
 				if (separation < (SEPARATION_RADIUS)){ //dependant on model size
@@ -134,19 +133,19 @@ __FLAME_GPU_FUNC__ int inputdata(xmachine_memory_Boid* xmemory, xmachine_message
 	fvec3 velocity_change = fvec3(0.0f, 0.0f, 0.0f);
 
 
-	//Rule 1) Steer towards perceived center of flock (Cohesion)
+	//Rule 1) Steer towards perceived centre of flock (Cohesion)
 	fvec3 steer_velocity = fvec3(0.0f, 0.0f, 0.0f);
-	if (global_centre_count >0){
-		global_centre /= global_centre_count;
-		steer_velocity = (global_centre - xmemory->position)* STEER_SCALE;
+	if (perceived_count >0){
+		perceived_centre /= perceived_count;
+		steer_velocity = (perceived_centre - xmemory->position) * STEER_SCALE;
 	}
 	velocity_change += steer_velocity; 
 
 	//Rule 2) Match neighbours speeds (Alignment)
 	fvec3 match_velocity = fvec3(0.0f, 0.0f, 0.0f);
 	if (collision_count > 0){
-		global_velocity /= global_centre_count;
-		match_velocity = global_velocity * MATCH_SCALE;
+		perceived_velocity /= perceived_count;
+		match_velocity = perceived_velocity * MATCH_SCALE;
 	}
 	velocity_change += match_velocity; 
 
@@ -154,7 +153,7 @@ __FLAME_GPU_FUNC__ int inputdata(xmachine_memory_Boid* xmemory, xmachine_message
 	fvec3 avoid_velocity = fvec3(0.0f, 0.0f, 0.0f);
 	if (collision_count > 0){
 		collision_centre /= collision_count;
-		avoid_velocity = (xmemory->position - collision_centre)* COLLISION_SCALE;
+		avoid_velocity = (xmemory->position - collision_centre) * COLLISION_SCALE;
 	}
 	velocity_change += avoid_velocity; 
 

--- a/examples/Boids_PartitioningVecTypes/src/model/functions.c
+++ b/examples/Boids_PartitioningVecTypes/src/model/functions.c
@@ -134,7 +134,7 @@ __FLAME_GPU_FUNC__ int inputdata(xmachine_memory_Boid* xmemory, xmachine_message
 	fvec3 velocity_change = fvec3(0.0f, 0.0f, 0.0f);
 
 
-	//Rule 1) Steer towards perceived center of flock
+	//Rule 1) Steer towards perceived center of flock (Cohesion)
 	fvec3 steer_velocity = fvec3(0.0f, 0.0f, 0.0f);
 	if (global_centre_count >0){
 		global_centre /= global_centre_count;
@@ -142,15 +142,15 @@ __FLAME_GPU_FUNC__ int inputdata(xmachine_memory_Boid* xmemory, xmachine_message
 	}
 	velocity_change += steer_velocity; 
 
-	//Rule 2) Match neighbours speeds
+	//Rule 2) Match neighbours speeds (Alignment)
 	fvec3 match_velocity = fvec3(0.0f, 0.0f, 0.0f);
 	if (collision_count > 0){
-		global_velocity /= collision_count;
-		match_velocity = match_velocity* MATCH_SCALE;
+		global_velocity /= global_centre_count;
+		match_velocity = global_velocity * MATCH_SCALE;
 	}
 	velocity_change += match_velocity; 
 
-	//Rule 3) Avoid close range neighbours
+	//Rule 3) Avoid close range neighbours (Separation)
 	fvec3 avoid_velocity = fvec3(0.0f, 0.0f, 0.0f);
 	if (collision_count > 0){
 		collision_centre /= collision_count;


### PR DESCRIPTION
The 3 implementations of the Boids models each contained 2 bugs relating to the calculation of the velocity matching (Alignment) rule, as highlighted in #62 .

I've confirmed that they were incorrect (`collision_velocity` always `{0.0f,0.0f,0.0f}`) and implemented the fix as suggested by @nikic.

I've also renamed some variables and modified some comments to add clarity, that the values are perceived values rather than global values (as they are within the interaction radius of the agent).