### PR TITLE
Support default values for vector types in the xml schema / xmlmodelfile

### DIFF
--- a/FLAMEGPU/schemas/XMML.xsd
+++ b/FLAMEGPU/schemas/XMML.xsd
@@ -32,12 +32,11 @@
 			</xs:element>
 		</xs:sequence>
 	</xs:complexType>
-	<xs:simpleType name="type_type">
-		<xs:restriction base="xs:string">
-			<xs:enumeration value="int" />
-			<xs:enumeration value="float" />
-			<xs:enumeration value="double" />
-		</xs:restriction>
+	<!-- Regular expression allowing (comma separate lists) of numerical values -->
+	<xs:simpleType name="defaultValue_type">
+	    <xs:restriction base="xs:token">
+	        <xs:pattern value="([\-\+]?[0-9]+(\.[0-9]+f?)?)[ ]*(,[ ]*([\-\+]?[0-9]+(\.[0-9]+f?)?)){0,3}"/>
+	    </xs:restriction>
 	</xs:simpleType>
 	<xs:complexType name="variable_type" abstract="true">
 		<xs:sequence>
@@ -45,7 +44,7 @@
 			<xs:element name="name" type="xs:string" maxOccurs="1" minOccurs="1" nillable="false" />
 			<xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1" />
 			<xs:element name="arrayLength" type="xs:int" minOccurs="0" maxOccurs="1" />
-			<xs:element name="defaultValue" type="xs:double" minOccurs="0" maxOccurs="1" />
+			<xs:element name="defaultValue" type="defaultValue_type" minOccurs="0" maxOccurs="1" />
 		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="environment_type" abstract="true">

--- a/FLAMEGPU/templates/FLAMEGPU_kernals.xslt
+++ b/FLAMEGPU/templates/FLAMEGPU_kernals.xslt
@@ -3,84 +3,10 @@
                 xmlns:xmml="http://www.dcs.shef.ac.uk/~paul/XMML"
                 xmlns:gpu="http://www.dcs.shef.ac.uk/~paul/XMMLGPU">
 <xsl:output method="text" version="1.0" encoding="UTF-8" indent="yes" />
-
-  
-<!--Recursive template for function conditions-->
-<xsl:template match="xmml:condition">(<xsl:choose>
-<xsl:when test="xmml:lhs/xmml:value"><xsl:value-of select="xmml:lhs/xmml:value"/>
-</xsl:when>
-<xsl:when test="xmml:lhs/xmml:agentVariable">currentState-><xsl:value-of select="xmml:lhs/xmml:agentVariable"/>[index]</xsl:when>
-<xsl:otherwise><xsl:apply-templates select="xmml:lhs/xmml:condition"/>
-</xsl:otherwise>
-</xsl:choose>
-<xsl:value-of select="xmml:operator"/>
-<xsl:choose>
-<xsl:when test="xmml:rhs/xmml:value"><xsl:value-of select="xmml:rhs/xmml:value"/>
-</xsl:when>
-<xsl:when test="xmml:rhs/xmml:agentVariable">currentState-><xsl:value-of select="xmml:rhs/xmml:agentVariable"/>[index]</xsl:when>
-<xsl:otherwise><xsl:apply-templates select="xmml:rhs/xmml:condition"/>
-</xsl:otherwise>
-</xsl:choose>)</xsl:template>
-
-<!--Recursive template for function global conditions-->
-<xsl:template match="gpu:globalCondition">(<xsl:choose>
-<xsl:when test="xmml:lhs/xmml:value"><xsl:value-of select="xmml:lhs/xmml:value"/>
-</xsl:when>
-<xsl:when test="xmml:lhs/xmml:agentVariable">currentState-><xsl:value-of select="xmml:lhs/xmml:agentVariable"/>[index]</xsl:when>
-<xsl:otherwise><xsl:apply-templates select="xmml:lhs/xmml:condition"/>
-</xsl:otherwise>
-</xsl:choose>
-<xsl:value-of select="xmml:operator"/>
-<xsl:choose>
-<xsl:when test="xmml:rhs/xmml:value"><xsl:value-of select="xmml:rhs/xmml:value"/>
-</xsl:when>
-<xsl:when test="xmml:rhs/xmml:agentVariable">currentState-><xsl:value-of select="xmml:rhs/xmml:agentVariable"/>[index]</xsl:when>
-<xsl:otherwise><xsl:apply-templates select="xmml:rhs/xmml:condition"/>
-</xsl:otherwise>
-</xsl:choose>)</xsl:template>
-
-<xsl:template name="defaultInitialiser">
-    <xsl:param name="type"/>
-    <xsl:choose>
-        <xsl:when test="$type='ivec2'">{0, 0}</xsl:when>
-        <xsl:when test="$type='uvec2'">{0, 0}</xsl:when>
-        <xsl:when test="$type='fvec2'">{0, 0}</xsl:when>
-        <xsl:when test="$type='dvec2'">{0, 0}</xsl:when>
-        
-        <xsl:when test="$type='ivec3'">{0, 0, 0}</xsl:when>
-        <xsl:when test="$type='uvec3'">{0, 0, 0}</xsl:when>
-        <xsl:when test="$type='fvec3'">{0, 0, 0}</xsl:when>
-        <xsl:when test="$type='dvec3'">{0, 0, 0}</xsl:when>
-        
-        <xsl:when test="$type='ivec4'">{0, 0, 0, 0}</xsl:when>
-        <xsl:when test="$type='uvec4'">{0, 0, 0, 0}</xsl:when>
-        <xsl:when test="$type='fvec4'">{0, 0, 0, 0}</xsl:when>
-        <xsl:when test="$type='dvec4'">{0, 0, 0, 0}</xsl:when>
-        
-        <xsl:otherwise>0</xsl:otherwise> <!-- default output format is float -->
-    </xsl:choose>
-</xsl:template> 
-
-
+<xsl:include href = "./_common_templates.xslt" />
 <!--Main template-->
 <xsl:template match="/">
-
-/*
-* FLAME GPU v 1.5.X for CUDA 9
-* Copyright University of Sheffield.
-* Original Author: Dr Paul Richmond (user contributions tracked on https://github.com/FLAMEGPU/FLAMEGPU)
-* Contact: p.richmond@sheffield.ac.uk (http://www.paulrichmond.staff.shef.ac.uk)
-*
-* University of Sheffield retain all intellectual property and
-* proprietary rights in and to this software and related documentation.
-* Any use, reproduction, disclosure, or distribution of this software
-* and related documentation without an express license agreement from
-* University of Sheffield is strictly prohibited.
-*
-* For terms of licence agreement please attached licence or view licence
-* on www.flamegpu.com website.
-*
-*/
+<xsl:call-template name="copyrightNotice"></xsl:call-template>
 
 #ifndef _FLAMEGPU_KERNELS_H_
 #define _FLAMEGPU_KERNELS_H_

--- a/FLAMEGPU/templates/_common_templates.xslt
+++ b/FLAMEGPU/templates/_common_templates.xslt
@@ -52,30 +52,36 @@
         <xsl:otherwise>%f</xsl:otherwise> <!-- default output format is float -->
     </xsl:choose>
 </xsl:template>
-  
 <!-- Default variable initialiser with optional default value argument -->
 <xsl:template name="defaultInitialiser">
     <xsl:param name="type"/>
     <xsl:param name="defaultValue"/>
+    <!-- find how many commas are in the value -->
+    <xsl:variable name="numCommas" select="string-length($defaultValue) - string-length(translate($defaultValue, ',', ''))" />
+    <!-- note that ends with does not exist in xslt 1, so must use multiple string operators... -->
     <xsl:choose>
-        <xsl:when test="$type='ivec2'">{<xsl:choose><xsl:when test="$defaultValue"><xsl:value-of select="$defaultValue"/></xsl:when><xsl:otherwise>0, 0</xsl:otherwise></xsl:choose>}</xsl:when>
-        <xsl:when test="$type='uvec2'">{<xsl:choose><xsl:when test="$defaultValue"><xsl:value-of select="$defaultValue"/></xsl:when><xsl:otherwise>0, 0</xsl:otherwise></xsl:choose>}</xsl:when>
-        <xsl:when test="$type='fvec2'">{<xsl:choose><xsl:when test="$defaultValue"><xsl:value-of select="$defaultValue"/></xsl:when><xsl:otherwise>0, 0</xsl:otherwise></xsl:choose>}</xsl:when>
-        <xsl:when test="$type='dvec2'">{<xsl:choose><xsl:when test="$defaultValue"><xsl:value-of select="$defaultValue"/></xsl:when><xsl:otherwise>0, 0</xsl:otherwise></xsl:choose>}</xsl:when>
-        
-        <xsl:when test="$type='ivec3'">{<xsl:choose><xsl:when test="$defaultValue"><xsl:value-of select="$defaultValue"/></xsl:when><xsl:otherwise>0, 0, 0</xsl:otherwise></xsl:choose>}</xsl:when>
-        <xsl:when test="$type='uvec3'">{<xsl:choose><xsl:when test="$defaultValue"><xsl:value-of select="$defaultValue"/></xsl:when><xsl:otherwise>0, 0, 0</xsl:otherwise></xsl:choose>}</xsl:when>
-        <xsl:when test="$type='fvec3'">{<xsl:choose><xsl:when test="$defaultValue"><xsl:value-of select="$defaultValue"/></xsl:when><xsl:otherwise>0, 0, 0</xsl:otherwise></xsl:choose>}</xsl:when>
-        <xsl:when test="$type='dvec3'">{<xsl:choose><xsl:when test="$defaultValue"><xsl:value-of select="$defaultValue"/></xsl:when><xsl:otherwise>0, 0, 0</xsl:otherwise></xsl:choose>}</xsl:when>
-        
-        <xsl:when test="$type='ivec4'">{<xsl:choose><xsl:when test="$defaultValue"><xsl:value-of select="$defaultValue"/></xsl:when><xsl:otherwise>0, 0, 0, 0</xsl:otherwise></xsl:choose>}</xsl:when>
-        <xsl:when test="$type='uvec4'">{<xsl:choose><xsl:when test="$defaultValue"><xsl:value-of select="$defaultValue"/></xsl:when><xsl:otherwise>0, 0, 0, 0</xsl:otherwise></xsl:choose>}</xsl:when>
-        <xsl:when test="$type='fvec4'">{<xsl:choose><xsl:when test="$defaultValue"><xsl:value-of select="$defaultValue"/></xsl:when><xsl:otherwise>0, 0, 0, 0</xsl:otherwise></xsl:choose>}</xsl:when>
-        <xsl:when test="$type='dvec4'">{<xsl:choose><xsl:when test="$defaultValue"><xsl:value-of select="$defaultValue"/></xsl:when><xsl:otherwise>0, 0, 0, 0</xsl:otherwise></xsl:choose>}</xsl:when>
-        
-        <!-- default output format is float -->
+        <xsl:when test="substring($type, string-length($type) - string-length('vec2') + 1) = 'vec2'"><xsl:choose>
+            <xsl:when test="$defaultValue and $numCommas=1">{<xsl:value-of select="$defaultValue" />}</xsl:when>
+            <xsl:otherwise>{0,0}</xsl:otherwise>
+        </xsl:choose>
+        </xsl:when>
+        <xsl:when test="substring($type, string-length($type) - string-length('vec3') + 1) = 'vec3'">
+            <xsl:choose>
+                <xsl:when test="$defaultValue and $numCommas=2">{<xsl:value-of select="$defaultValue" />}</xsl:when>
+                <xsl:otherwise>{0,0,0}</xsl:otherwise>
+            </xsl:choose>
+        </xsl:when>
+        <xsl:when test="substring($type, string-length($type) - string-length('vec4') + 1) = 'vec4'">
+            <xsl:choose>
+                <xsl:when test="$defaultValue and $numCommas=3">{<xsl:value-of select="$defaultValue" />}</xsl:when>
+                <xsl:otherwise>{0,0,0,0}</xsl:otherwise>
+            </xsl:choose>
+        </xsl:when>
         <xsl:otherwise>
-            <xsl:choose><xsl:when test="$defaultValue"><xsl:value-of select="$defaultValue"/></xsl:when><xsl:otherwise>0</xsl:otherwise></xsl:choose>
+            <xsl:choose>
+                <xsl:when test="$defaultValue and $numCommas=0"><xsl:value-of select="$defaultValue" /></xsl:when>
+                <xsl:otherwise>0</xsl:otherwise>
+            </xsl:choose>
         </xsl:otherwise>
     </xsl:choose>
 </xsl:template>

--- a/FLAMEGPU/templates/_common_templates.xslt
+++ b/FLAMEGPU/templates/_common_templates.xslt
@@ -1,0 +1,232 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xmml="http://www.dcs.shef.ac.uk/~paul/XMML" xmlns:gpu="http://www.dcs.shef.ac.uk/~paul/XMMLGPU">
+
+<xsl:template name="copyrightNotice">
+/*
+ * FLAME GPU v 1.5.X for CUDA 9
+ * Copyright University of Sheffield.
+ * Original Author: Dr Paul Richmond (user contributions tracked on https://github.com/FLAMEGPU/FLAMEGPU)
+ * Contact: p.richmond@sheffield.ac.uk (http://www.paulrichmond.staff.shef.ac.uk)
+ *
+ * University of Sheffield retain all intellectual property and
+ * proprietary rights in and to this software and related documentation.
+ * Any use, reproduction, disclosure, or distribution of this software
+ * and related documentation without an express license agreement from
+ * University of Sheffield is strictly prohibited.
+ *
+ * For terms of licence agreement please attached licence or view licence
+ * on www.flamegpu.com website.
+ *
+ */
+</xsl:template>
+
+
+<!-- format specifier template function -->
+<xsl:template name="formatSpecifier">
+    <xsl:param name="type"/>
+    <xsl:choose>
+        <xsl:when test="$type='char'">%d</xsl:when>
+        <xsl:when test="$type='unsigned char'">%u</xsl:when>
+        <xsl:when test="$type='short'">%d</xsl:when>
+        <xsl:when test="$type='unsigned short'">%u</xsl:when>
+        <xsl:when test="$type='int'">%d</xsl:when>
+        <xsl:when test="$type='unsigned int'">%u</xsl:when>
+        <xsl:when test="$type='long long int'">%lld</xsl:when>
+        <xsl:when test="$type='unsigned long long int'">%llu</xsl:when>
+        
+        <xsl:when test="$type='ivec2'">%d, %d</xsl:when>
+        <xsl:when test="$type='uvec2'">%u, %u</xsl:when>
+        <xsl:when test="$type='fvec2'">%f, %f</xsl:when>
+        <xsl:when test="$type='dvec2'">%f, %f</xsl:when>
+        
+        <xsl:when test="$type='ivec3'">%d, %d, %d</xsl:when>
+        <xsl:when test="$type='uvec3'">%u, %u, %u</xsl:when>
+        <xsl:when test="$type='fvec3'">%f, %f, %f</xsl:when>
+        <xsl:when test="$type='dvec3'">%f, %f, %f</xsl:when>
+        
+        <xsl:when test="$type='ivec4'">%d, %d, %d, %d</xsl:when>
+        <xsl:when test="$type='uvec4'">%u, %u, %u, %u</xsl:when>
+        <xsl:when test="$type='fvec4'">%f, %f, %f, %f</xsl:when>
+        <xsl:when test="$type='dvec4'">%f, %f, %f, %f</xsl:when>
+        
+        <xsl:otherwise>%f</xsl:otherwise> <!-- default output format is float -->
+    </xsl:choose>
+</xsl:template>
+  
+<!-- Default variable initialiser with optional default value argument -->
+<xsl:template name="defaultInitialiser">
+    <xsl:param name="type"/>
+    <xsl:param name="defaultValue"/>
+    <xsl:choose>
+        <xsl:when test="$type='ivec2'">{<xsl:choose><xsl:when test="$defaultValue"><xsl:value-of select="$defaultValue"/></xsl:when><xsl:otherwise>0, 0</xsl:otherwise></xsl:choose>}</xsl:when>
+        <xsl:when test="$type='uvec2'">{<xsl:choose><xsl:when test="$defaultValue"><xsl:value-of select="$defaultValue"/></xsl:when><xsl:otherwise>0, 0</xsl:otherwise></xsl:choose>}</xsl:when>
+        <xsl:when test="$type='fvec2'">{<xsl:choose><xsl:when test="$defaultValue"><xsl:value-of select="$defaultValue"/></xsl:when><xsl:otherwise>0, 0</xsl:otherwise></xsl:choose>}</xsl:when>
+        <xsl:when test="$type='dvec2'">{<xsl:choose><xsl:when test="$defaultValue"><xsl:value-of select="$defaultValue"/></xsl:when><xsl:otherwise>0, 0</xsl:otherwise></xsl:choose>}</xsl:when>
+        
+        <xsl:when test="$type='ivec3'">{<xsl:choose><xsl:when test="$defaultValue"><xsl:value-of select="$defaultValue"/></xsl:when><xsl:otherwise>0, 0, 0</xsl:otherwise></xsl:choose>}</xsl:when>
+        <xsl:when test="$type='uvec3'">{<xsl:choose><xsl:when test="$defaultValue"><xsl:value-of select="$defaultValue"/></xsl:when><xsl:otherwise>0, 0, 0</xsl:otherwise></xsl:choose>}</xsl:when>
+        <xsl:when test="$type='fvec3'">{<xsl:choose><xsl:when test="$defaultValue"><xsl:value-of select="$defaultValue"/></xsl:when><xsl:otherwise>0, 0, 0</xsl:otherwise></xsl:choose>}</xsl:when>
+        <xsl:when test="$type='dvec3'">{<xsl:choose><xsl:when test="$defaultValue"><xsl:value-of select="$defaultValue"/></xsl:when><xsl:otherwise>0, 0, 0</xsl:otherwise></xsl:choose>}</xsl:when>
+        
+        <xsl:when test="$type='ivec4'">{<xsl:choose><xsl:when test="$defaultValue"><xsl:value-of select="$defaultValue"/></xsl:when><xsl:otherwise>0, 0, 0, 0</xsl:otherwise></xsl:choose>}</xsl:when>
+        <xsl:when test="$type='uvec4'">{<xsl:choose><xsl:when test="$defaultValue"><xsl:value-of select="$defaultValue"/></xsl:when><xsl:otherwise>0, 0, 0, 0</xsl:otherwise></xsl:choose>}</xsl:when>
+        <xsl:when test="$type='fvec4'">{<xsl:choose><xsl:when test="$defaultValue"><xsl:value-of select="$defaultValue"/></xsl:when><xsl:otherwise>0, 0, 0, 0</xsl:otherwise></xsl:choose>}</xsl:when>
+        <xsl:when test="$type='dvec4'">{<xsl:choose><xsl:when test="$defaultValue"><xsl:value-of select="$defaultValue"/></xsl:when><xsl:otherwise>0, 0, 0, 0</xsl:otherwise></xsl:choose>}</xsl:when>
+        
+        <!-- default output format is float -->
+        <xsl:otherwise>
+            <xsl:choose><xsl:when test="$defaultValue"><xsl:value-of select="$defaultValue"/></xsl:when><xsl:otherwise>0</xsl:otherwise></xsl:choose>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+
+
+<!-- argument list generator for agent variable outputs -->
+<xsl:template name="outputVariable">
+    <xsl:param name="agent_name"/>
+    <xsl:param name="state_name"/>
+    <xsl:param name="variable_name"/>
+    <xsl:param name="variable_type"/>
+    <xsl:choose>      
+        <xsl:when test="contains($variable_type, '2')">h_<xsl:value-of select="$agent_name"/>s_<xsl:value-of select="$state_name"/>-><xsl:value-of select="$variable_name"/>[i].x, h_<xsl:value-of select="$agent_name"/>s_<xsl:value-of select="$state_name"/>-><xsl:value-of select="$variable_name"/>[i].y</xsl:when>
+        <xsl:when test="contains($variable_type, '3')">h_<xsl:value-of select="$agent_name"/>s_<xsl:value-of select="$state_name"/>-><xsl:value-of select="$variable_name"/>[i].x, h_<xsl:value-of select="$agent_name"/>s_<xsl:value-of select="$state_name"/>-><xsl:value-of select="$variable_name"/>[i].y, h_<xsl:value-of select="$agent_name"/>s_<xsl:value-of select="$state_name"/>-><xsl:value-of select="$variable_name"/>[i].z</xsl:when>
+        <xsl:when test="contains($variable_type, '4')">h_<xsl:value-of select="$agent_name"/>s_<xsl:value-of select="$state_name"/>-><xsl:value-of select="$variable_name"/>[i].x, h_<xsl:value-of select="$agent_name"/>s_<xsl:value-of select="$state_name"/>-><xsl:value-of select="$variable_name"/>[i].y, h_<xsl:value-of select="$agent_name"/>s_<xsl:value-of select="$state_name"/>-><xsl:value-of select="$variable_name"/>[i].z, h_<xsl:value-of select="$agent_name"/>s_<xsl:value-of select="$state_name"/>-><xsl:value-of select="$variable_name"/>[i].w</xsl:when>
+        <xsl:otherwise>h_<xsl:value-of select="$agent_name"/>s_<xsl:value-of select="$state_name"/>-><xsl:value-of select="$variable_name"/>[i]</xsl:otherwise> <!-- default output format is scalar type -->
+    </xsl:choose>
+</xsl:template>
+  
+<!-- argument list generator for agent variable array outputs --> 
+<xsl:template name="outputVariableArrayItem">
+    <xsl:param name="agent_name"/>
+    <xsl:param name="state_name"/>
+    <xsl:param name="variable_name"/>
+    <xsl:param name="variable_type"/>
+    <xsl:choose>      
+        <xsl:when test="contains($variable_type, '2')">h_<xsl:value-of select="$agent_name"/>s_<xsl:value-of select="$state_name"/>-><xsl:value-of select="$variable_name"/>[(j*xmachine_memory_<xsl:value-of select="$agent_name"/>_MAX)+i].x, h_<xsl:value-of select="$agent_name"/>s_<xsl:value-of select="$state_name"/>-><xsl:value-of select="$variable_name"/>[(j*xmachine_memory_<xsl:value-of select="$agent_name"/>_MAX)+i].y</xsl:when>
+        <xsl:when test="contains($variable_type, '3')">h_<xsl:value-of select="$agent_name"/>s_<xsl:value-of select="$state_name"/>-><xsl:value-of select="$variable_name"/>[(j*xmachine_memory_<xsl:value-of select="$agent_name"/>_MAX)+i].x, h_<xsl:value-of select="$agent_name"/>s_<xsl:value-of select="$state_name"/>-><xsl:value-of select="$variable_name"/>[(j*xmachine_memory_<xsl:value-of select="$agent_name"/>_MAX)+i].y, h_<xsl:value-of select="$agent_name"/>s_<xsl:value-of select="$state_name"/>-><xsl:value-of select="$variable_name"/>[(j*xmachine_memory_<xsl:value-of select="$agent_name"/>_MAX)+i].z</xsl:when>
+        <xsl:when test="contains($variable_type, '4')">h_<xsl:value-of select="$agent_name"/>s_<xsl:value-of select="$state_name"/>-><xsl:value-of select="$variable_name"/>[(j*xmachine_memory_<xsl:value-of select="$agent_name"/>_MAX)+i].x, h_<xsl:value-of select="$agent_name"/>s_<xsl:value-of select="$state_name"/>-><xsl:value-of select="$variable_name"/>[(j*xmachine_memory_<xsl:value-of select="$agent_name"/>_MAX)+i].y, h_<xsl:value-of select="$agent_name"/>s_<xsl:value-of select="$state_name"/>-><xsl:value-of select="$variable_name"/>[(j*xmachine_memory_<xsl:value-of select="$agent_name"/>_MAX)+i].z, h_<xsl:value-of select="$agent_name"/>s_<xsl:value-of select="$state_name"/>-><xsl:value-of select="$variable_name"/>[(j*xmachine_memory_<xsl:value-of select="$agent_name"/>_MAX)+i].w</xsl:when>
+        <xsl:otherwise>h_<xsl:value-of select="$agent_name"/>s_<xsl:value-of select="$state_name"/>-><xsl:value-of select="$variable_name"/>[(j*xmachine_memory_<xsl:value-of select="$agent_name"/>_MAX)+i]</xsl:otherwise> <!-- default output format is scalar type -->
+    </xsl:choose>
+</xsl:template>
+
+<!-- argument list generator for agent variable outputs -->
+<xsl:template name="outputEnvironmentConstant">
+    <xsl:param name="constant_name"/>
+    <xsl:param name="constant_type"/>
+    <xsl:choose>      
+        <xsl:when test="contains($constant_type, '2')">(*get_<xsl:value-of select="$constant_name"/>()).x, (*get_<xsl:value-of select="$constant_name"/>()).y</xsl:when>
+        <xsl:when test="contains($constant_type, '3')">(*get_<xsl:value-of select="$constant_name"/>()).x, (*get_<xsl:value-of select="$constant_name"/>()).y, (*get_<xsl:value-of select="$constant_name"/>()).z</xsl:when>
+        <xsl:when test="contains($constant_type, '4')">(*get_<xsl:value-of select="$constant_name"/>()).x, (*get_<xsl:value-of select="$constant_name"/>()).y, (*get_<xsl:value-of select="$constant_name"/>()).z, (*get_<xsl:value-of select="$constant_name"/>()).w</xsl:when>
+        <xsl:otherwise>(*get_<xsl:value-of select="$constant_name"/>())</xsl:otherwise> <!-- default output format is scalar type -->
+    </xsl:choose>
+</xsl:template>
+
+
+
+<!-- argument list generator for environment constant array outputs --> 
+<xsl:template name="outputEnvironmentConstantArrayItem">
+    <xsl:param name="constant_name"/>
+    <xsl:param name="constant_type"/>
+    <xsl:choose>      
+        <xsl:when test="contains($constant_type, '2')">get_<xsl:value-of select="$constant_name"/>()[j].x, get_<xsl:value-of select="$constant_name"/>()[j].y</xsl:when>
+        <xsl:when test="contains($constant_type, '3')">get_<xsl:value-of select="$constant_name"/>()[j].x, get_<xsl:value-of select="$constant_name"/>()[j].y, get_<xsl:value-of select="$constant_name"/>()[j].z</xsl:when>
+        <xsl:when test="contains($constant_type, '4')">get_<xsl:value-of select="$constant_name"/>()[j].x, get_<xsl:value-of select="$constant_name"/>()[j].y, get_<xsl:value-of select="$constant_name"/>()[j].z, get_<xsl:value-of select="$constant_name"/>()[j].w</xsl:when>
+        <xsl:otherwise>get_<xsl:value-of select="$constant_name"/>()[j]</xsl:otherwise> <!-- default output format is scalar type -->
+    </xsl:choose>
+</xsl:template>
+
+<!-- function pointer for reading variable types from string --> 
+<xsl:template name="typeParserFunc">
+    <xsl:param name="type"/>
+    <xsl:choose>      
+        <xsl:when test="$type='char'">fpgu_strtol</xsl:when>
+        <xsl:when test="$type='unsigned char'">fpgu_strtoul</xsl:when>
+        <xsl:when test="$type='short'">fpgu_strtol</xsl:when>
+        <xsl:when test="$type='unsigned short'">fpgu_strtoul</xsl:when>
+        <xsl:when test="$type='int'">fpgu_strtol</xsl:when>
+        <xsl:when test="$type='unsigned int'">fpgu_strtoul</xsl:when>
+        <xsl:when test="$type='long long int'">fpgu_strtoll</xsl:when>
+        <xsl:when test="$type='unsigned long long int'">fpgu_strtoull</xsl:when> 
+        <xsl:when test="$type='double'">fpgu_strtod</xsl:when>
+        <xsl:when test="$type='float'">fgpu_atof</xsl:when>
+      
+        <xsl:when test="$type='ivec2'">fpgu_strtol</xsl:when>
+        <xsl:when test="$type='uvec2'">fpgu_strtoul</xsl:when>
+        <xsl:when test="$type='fvec2'">fgpu_atof</xsl:when>
+        <xsl:when test="$type='dvec2'">fpgu_strtod</xsl:when>
+        
+        <xsl:when test="$type='ivec3'">fpgu_strtol</xsl:when>
+        <xsl:when test="$type='uvec3'">fpgu_strtoul</xsl:when>
+        <xsl:when test="$type='fvec3'">fgpu_atof</xsl:when>
+        <xsl:when test="$type='dvec3'">fpgu_strtod</xsl:when>
+      
+        <xsl:when test="$type='ivec4'">fpgu_strtol</xsl:when>
+        <xsl:when test="$type='uvec4'">fpgu_strtoul</xsl:when>
+        <xsl:when test="$type='fvec4'">fgpu_atof</xsl:when>
+        <xsl:when test="$type='dvec4'">fpgu_strtod</xsl:when>
+      
+        <xsl:otherwise>atof</xsl:otherwise> <!-- default parse function as float -->
+    </xsl:choose>
+</xsl:template>
+  
+  <!-- function pointer for reading variable types from string --> 
+<xsl:template name="vectorBaseType">
+    <xsl:param name="type"/>
+    <xsl:choose>        
+        <xsl:when test="$type='ivec2'">int</xsl:when>
+        <xsl:when test="$type='uvec2'">unsigned int</xsl:when>
+        <xsl:when test="$type='fvec2'">float</xsl:when>
+        <xsl:when test="$type='dvec2'">double</xsl:when>
+        
+        <xsl:when test="$type='ivec3'">int</xsl:when>
+        <xsl:when test="$type='uvec3'">unsigned int</xsl:when>
+        <xsl:when test="$type='fvec3'">float</xsl:when>
+        <xsl:when test="$type='dvec3'">double</xsl:when>
+      
+        <xsl:when test="$type='ivec4'">int</xsl:when>
+        <xsl:when test="$type='uvec4'">unsigned int</xsl:when>
+        <xsl:when test="$type='fvec4'">float</xsl:when>
+        <xsl:when test="$type='dvec4'">double</xsl:when>
+      
+        <xsl:otherwise>float</xsl:otherwise> <!-- default base type of float -->
+    </xsl:choose>
+</xsl:template>
+
+
+
+<!--Recursive template for function conditions-->
+<xsl:template match="xmml:condition">(<xsl:choose>
+<xsl:when test="xmml:lhs/xmml:value"><xsl:value-of select="xmml:lhs/xmml:value"/>
+</xsl:when>
+<xsl:when test="xmml:lhs/xmml:agentVariable">currentState-><xsl:value-of select="xmml:lhs/xmml:agentVariable"/>[index]</xsl:when>
+<xsl:otherwise><xsl:apply-templates select="xmml:lhs/xmml:condition"/>
+</xsl:otherwise>
+</xsl:choose>
+<xsl:value-of select="xmml:operator"/>
+<xsl:choose>
+<xsl:when test="xmml:rhs/xmml:value"><xsl:value-of select="xmml:rhs/xmml:value"/>
+</xsl:when>
+<xsl:when test="xmml:rhs/xmml:agentVariable">currentState-><xsl:value-of select="xmml:rhs/xmml:agentVariable"/>[index]</xsl:when>
+<xsl:otherwise><xsl:apply-templates select="xmml:rhs/xmml:condition"/>
+</xsl:otherwise>
+</xsl:choose>)</xsl:template>
+
+<!--Recursive template for function global conditions-->
+<xsl:template match="gpu:globalCondition">(<xsl:choose>
+<xsl:when test="xmml:lhs/xmml:value"><xsl:value-of select="xmml:lhs/xmml:value"/>
+</xsl:when>
+<xsl:when test="xmml:lhs/xmml:agentVariable">currentState-><xsl:value-of select="xmml:lhs/xmml:agentVariable"/>[index]</xsl:when>
+<xsl:otherwise><xsl:apply-templates select="xmml:lhs/xmml:condition"/>
+</xsl:otherwise>
+</xsl:choose>
+<xsl:value-of select="xmml:operator"/>
+<xsl:choose>
+<xsl:when test="xmml:rhs/xmml:value"><xsl:value-of select="xmml:rhs/xmml:value"/>
+</xsl:when>
+<xsl:when test="xmml:rhs/xmml:agentVariable">currentState-><xsl:value-of select="xmml:rhs/xmml:agentVariable"/>[index]</xsl:when>
+<xsl:otherwise><xsl:apply-templates select="xmml:rhs/xmml:condition"/>
+</xsl:otherwise>
+</xsl:choose>)</xsl:template>
+
+</xsl:stylesheet>

--- a/FLAMEGPU/templates/functions.xslt
+++ b/FLAMEGPU/templates/functions.xslt
@@ -3,23 +3,10 @@
                 xmlns:xmml="http://www.dcs.shef.ac.uk/~paul/XMML"
                 xmlns:gpu="http://www.dcs.shef.ac.uk/~paul/XMMLGPU">
 <xsl:output method="text" version="1.0" encoding="UTF-8" indent="yes" />
+<xsl:include href = "./_common_templates.xslt" />
 <!--Main template-->
 <xsl:template match="/">
-/*
- * Copyright 2011 University of Sheffield.
- * Author: Dr Paul Richmond 
- * Contact: p.richmond@sheffield.ac.uk (http://www.paulrichmond.staff.shef.ac.uk)
- *
- * University of Sheffield retain all intellectual property and 
- * proprietary rights in and to this software and related documentation. 
- * Any use, reproduction, disclosure, or distribution of this software 
- * and related documentation without an express license agreement from
- * University of Sheffield is strictly prohibited.
- *
- * For terms of licence agreement please attached licence or view licence 
- * on www.flamegpu.com website.
- * 
- */
+<xsl:call-template name="copyrightNotice"></xsl:call-template>
 
 #ifndef _FLAMEGPU_FUNCTIONS
 #define _FLAMEGPU_FUNCTIONS

--- a/FLAMEGPU/templates/header.xslt
+++ b/FLAMEGPU/templates/header.xslt
@@ -3,23 +3,9 @@
                 xmlns:xmml="http://www.dcs.shef.ac.uk/~paul/XMML"
                 xmlns:gpu="http://www.dcs.shef.ac.uk/~paul/XMMLGPU">
 <xsl:output method="text" version="1.0" encoding="UTF-8" indent="yes" />
+<xsl:include href = "./_common_templates.xslt" />
 <xsl:template match="/">
-/*
-* FLAME GPU v 1.5.X for CUDA 9
-* Copyright University of Sheffield.
-* Original Author: Dr Paul Richmond (user contributions tracked on https://github.com/FLAMEGPU/FLAMEGPU)
-* Contact: p.richmond@sheffield.ac.uk (http://www.paulrichmond.staff.shef.ac.uk)
-*
-* University of Sheffield retain all intellectual property and
-* proprietary rights in and to this software and related documentation.
-* Any use, reproduction, disclosure, or distribution of this software
-* and related documentation without an express license agreement from
-* University of Sheffield is strictly prohibited.
-*
-* For terms of licence agreement please attached licence or view licence
-* on www.flamegpu.com website.
-*
-*/
+<xsl:call-template name="copyrightNotice"></xsl:call-template>
 
 #ifndef __HEADER
 #define __HEADER

--- a/FLAMEGPU/templates/io.xslt
+++ b/FLAMEGPU/templates/io.xslt
@@ -3,191 +3,9 @@
                 xmlns:xmml="http://www.dcs.shef.ac.uk/~paul/XMML"
                 xmlns:gpu="http://www.dcs.shef.ac.uk/~paul/XMMLGPU">
 <xsl:output method="text" version="1.0" encoding="UTF-8" indent="yes" />
-
-<!-- format specifier template function -->
-<xsl:template name="formatSpecifier">
-    <xsl:param name="type"/>
-    <xsl:choose>
-        <xsl:when test="$type='char'">%d</xsl:when>
-        <xsl:when test="$type='unsigned char'">%u</xsl:when>
-        <xsl:when test="$type='short'">%d</xsl:when>
-        <xsl:when test="$type='unsigned short'">%u</xsl:when>
-        <xsl:when test="$type='int'">%d</xsl:when>
-        <xsl:when test="$type='unsigned int'">%u</xsl:when>
-        <xsl:when test="$type='long long int'">%lld</xsl:when>
-        <xsl:when test="$type='unsigned long long int'">%llu</xsl:when>
-        
-        <xsl:when test="$type='ivec2'">%d, %d</xsl:when>
-        <xsl:when test="$type='uvec2'">%u, %u</xsl:when>
-        <xsl:when test="$type='fvec2'">%f, %f</xsl:when>
-        <xsl:when test="$type='dvec2'">%f, %f</xsl:when>
-        
-        <xsl:when test="$type='ivec3'">%d, %d, %d</xsl:when>
-        <xsl:when test="$type='uvec3'">%u, %u, %u</xsl:when>
-        <xsl:when test="$type='fvec3'">%f, %f, %f</xsl:when>
-        <xsl:when test="$type='dvec3'">%f, %f, %f</xsl:when>
-        
-        <xsl:when test="$type='ivec4'">%d, %d, %d, %d</xsl:when>
-        <xsl:when test="$type='uvec4'">%u, %u, %u, %u</xsl:when>
-        <xsl:when test="$type='fvec4'">%f, %f, %f, %f</xsl:when>
-        <xsl:when test="$type='dvec4'">%f, %f, %f, %f</xsl:when>
-        
-        <xsl:otherwise>%f</xsl:otherwise> <!-- default output format is float -->
-    </xsl:choose>
-</xsl:template>
-  
-  
-<!-- default initialiser -->
-<xsl:template name="defaultInitialiser">
-    <xsl:param name="type"/>
-    <xsl:choose>
-        <xsl:when test="$type='ivec2'">{0, 0}</xsl:when>
-        <xsl:when test="$type='uvec2'">{0, 0}</xsl:when>
-        <xsl:when test="$type='fvec2'">{0, 0}</xsl:when>
-        <xsl:when test="$type='dvec2'">{0, 0}</xsl:when>
-        
-        <xsl:when test="$type='ivec3'">{0, 0, 0}</xsl:when>
-        <xsl:when test="$type='uvec3'">{0, 0, 0}</xsl:when>
-        <xsl:when test="$type='fvec3'">{0, 0, 0}</xsl:when>
-        <xsl:when test="$type='dvec3'">{0, 0, 0}</xsl:when>
-        
-        <xsl:when test="$type='ivec4'">{0, 0, 0, 0}</xsl:when>
-        <xsl:when test="$type='uvec4'">{0, 0, 0, 0}</xsl:when>
-        <xsl:when test="$type='fvec4'">{0, 0, 0, 0}</xsl:when>
-        <xsl:when test="$type='dvec4'">{0, 0, 0, 0}</xsl:when>
-        
-        <xsl:otherwise>0</xsl:otherwise> <!-- default output format is float -->
-    </xsl:choose>
-</xsl:template>
-<!-- argument list generator for agent variable outputs -->
-<xsl:template name="outputVariable">
-    <xsl:param name="agent_name"/>
-    <xsl:param name="state_name"/>
-    <xsl:param name="variable_name"/>
-    <xsl:param name="variable_type"/>
-    <xsl:choose>      
-        <xsl:when test="contains($variable_type, '2')">h_<xsl:value-of select="$agent_name"/>s_<xsl:value-of select="$state_name"/>-><xsl:value-of select="$variable_name"/>[i].x, h_<xsl:value-of select="$agent_name"/>s_<xsl:value-of select="$state_name"/>-><xsl:value-of select="$variable_name"/>[i].y</xsl:when>
-        <xsl:when test="contains($variable_type, '3')">h_<xsl:value-of select="$agent_name"/>s_<xsl:value-of select="$state_name"/>-><xsl:value-of select="$variable_name"/>[i].x, h_<xsl:value-of select="$agent_name"/>s_<xsl:value-of select="$state_name"/>-><xsl:value-of select="$variable_name"/>[i].y, h_<xsl:value-of select="$agent_name"/>s_<xsl:value-of select="$state_name"/>-><xsl:value-of select="$variable_name"/>[i].z</xsl:when>
-        <xsl:when test="contains($variable_type, '4')">h_<xsl:value-of select="$agent_name"/>s_<xsl:value-of select="$state_name"/>-><xsl:value-of select="$variable_name"/>[i].x, h_<xsl:value-of select="$agent_name"/>s_<xsl:value-of select="$state_name"/>-><xsl:value-of select="$variable_name"/>[i].y, h_<xsl:value-of select="$agent_name"/>s_<xsl:value-of select="$state_name"/>-><xsl:value-of select="$variable_name"/>[i].z, h_<xsl:value-of select="$agent_name"/>s_<xsl:value-of select="$state_name"/>-><xsl:value-of select="$variable_name"/>[i].w</xsl:when>
-        <xsl:otherwise>h_<xsl:value-of select="$agent_name"/>s_<xsl:value-of select="$state_name"/>-><xsl:value-of select="$variable_name"/>[i]</xsl:otherwise> <!-- default output format is scalar type -->
-    </xsl:choose>
-</xsl:template>
-  
-<!-- argument list generator for agent variable array outputs --> 
-<xsl:template name="outputVariableArrayItem">
-    <xsl:param name="agent_name"/>
-    <xsl:param name="state_name"/>
-    <xsl:param name="variable_name"/>
-    <xsl:param name="variable_type"/>
-    <xsl:choose>      
-        <xsl:when test="contains($variable_type, '2')">h_<xsl:value-of select="$agent_name"/>s_<xsl:value-of select="$state_name"/>-><xsl:value-of select="$variable_name"/>[(j*xmachine_memory_<xsl:value-of select="$agent_name"/>_MAX)+i].x, h_<xsl:value-of select="$agent_name"/>s_<xsl:value-of select="$state_name"/>-><xsl:value-of select="$variable_name"/>[(j*xmachine_memory_<xsl:value-of select="$agent_name"/>_MAX)+i].y</xsl:when>
-        <xsl:when test="contains($variable_type, '3')">h_<xsl:value-of select="$agent_name"/>s_<xsl:value-of select="$state_name"/>-><xsl:value-of select="$variable_name"/>[(j*xmachine_memory_<xsl:value-of select="$agent_name"/>_MAX)+i].x, h_<xsl:value-of select="$agent_name"/>s_<xsl:value-of select="$state_name"/>-><xsl:value-of select="$variable_name"/>[(j*xmachine_memory_<xsl:value-of select="$agent_name"/>_MAX)+i].y, h_<xsl:value-of select="$agent_name"/>s_<xsl:value-of select="$state_name"/>-><xsl:value-of select="$variable_name"/>[(j*xmachine_memory_<xsl:value-of select="$agent_name"/>_MAX)+i].z</xsl:when>
-        <xsl:when test="contains($variable_type, '4')">h_<xsl:value-of select="$agent_name"/>s_<xsl:value-of select="$state_name"/>-><xsl:value-of select="$variable_name"/>[(j*xmachine_memory_<xsl:value-of select="$agent_name"/>_MAX)+i].x, h_<xsl:value-of select="$agent_name"/>s_<xsl:value-of select="$state_name"/>-><xsl:value-of select="$variable_name"/>[(j*xmachine_memory_<xsl:value-of select="$agent_name"/>_MAX)+i].y, h_<xsl:value-of select="$agent_name"/>s_<xsl:value-of select="$state_name"/>-><xsl:value-of select="$variable_name"/>[(j*xmachine_memory_<xsl:value-of select="$agent_name"/>_MAX)+i].z, h_<xsl:value-of select="$agent_name"/>s_<xsl:value-of select="$state_name"/>-><xsl:value-of select="$variable_name"/>[(j*xmachine_memory_<xsl:value-of select="$agent_name"/>_MAX)+i].w</xsl:when>
-        <xsl:otherwise>h_<xsl:value-of select="$agent_name"/>s_<xsl:value-of select="$state_name"/>-><xsl:value-of select="$variable_name"/>[(j*xmachine_memory_<xsl:value-of select="$agent_name"/>_MAX)+i]</xsl:otherwise> <!-- default output format is scalar type -->
-    </xsl:choose>
-</xsl:template>
-
-<!-- argument list generator for agent variable outputs -->
-<xsl:template name="outputEnvironmentConstant">
-    <xsl:param name="constant_name"/>
-    <xsl:param name="constant_type"/>
-    <xsl:choose>      
-        <xsl:when test="contains($constant_type, '2')">*get_<xsl:value-of select="$constant_name"/>().x, *get_<xsl:value-of select="$constant_name"/>().y</xsl:when>
-        <xsl:when test="contains($constant_type, '3')">*get_<xsl:value-of select="$constant_name"/>().x, *get_<xsl:value-of select="$constant_name"/>().y, *get_<xsl:value-of select="$constant_name"/>().z</xsl:when>
-        <xsl:when test="contains($constant_type, '4')">*get_<xsl:value-of select="$constant_name"/>().x, *get_<xsl:value-of select="$constant_name"/>().y, *get_<xsl:value-of select="$constant_name"/>().z, *get_<xsl:value-of select="$constant_name"/>().w</xsl:when>
-        <xsl:otherwise>*get_<xsl:value-of select="$constant_name"/>()</xsl:otherwise> <!-- default output format is scalar type -->
-    </xsl:choose>
-</xsl:template>
-
-
-
-<!-- argument list generator for environment constant array outputs --> 
-<xsl:template name="outputEnvironmentConstantArrayItem">
-    <xsl:param name="constant_name"/>
-    <xsl:param name="constant_type"/>
-    <xsl:choose>      
-        <xsl:when test="contains($constant_type, '2')">get_<xsl:value-of select="$constant_name"/>()[j].x, get_<xsl:value-of select="$constant_name"/>()[j].y</xsl:when>
-        <xsl:when test="contains($constant_type, '3')">get_<xsl:value-of select="$constant_name"/>()[j].x, get_<xsl:value-of select="$constant_name"/>()[j].y, get_<xsl:value-of select="$constant_name"/>()[j].z</xsl:when>
-        <xsl:when test="contains($constant_type, '4')">get_<xsl:value-of select="$constant_name"/>()[j].x, get_<xsl:value-of select="$constant_name"/>()[j].y, get_<xsl:value-of select="$constant_name"/>()[j].z, get_<xsl:value-of select="$constant_name"/>()[j].w</xsl:when>
-        <xsl:otherwise>get_<xsl:value-of select="$constant_name"/>()[j]</xsl:otherwise> <!-- default output format is scalar type -->
-    </xsl:choose>
-</xsl:template>
-
-<!-- function pointer for reading variable types from string --> 
-<xsl:template name="typeParserFunc">
-    <xsl:param name="type"/>
-    <xsl:choose>      
-        <xsl:when test="$type='char'">fpgu_strtol</xsl:when>
-        <xsl:when test="$type='unsigned char'">fpgu_strtoul</xsl:when>
-        <xsl:when test="$type='short'">fpgu_strtol</xsl:when>
-        <xsl:when test="$type='unsigned short'">fpgu_strtoul</xsl:when>
-        <xsl:when test="$type='int'">fpgu_strtol</xsl:when>
-        <xsl:when test="$type='unsigned int'">fpgu_strtoul</xsl:when>
-        <xsl:when test="$type='long long int'">fpgu_strtoll</xsl:when>
-        <xsl:when test="$type='unsigned long long int'">fpgu_strtoull</xsl:when> 
-        <xsl:when test="$type='double'">fpgu_strtod</xsl:when>
-        <xsl:when test="$type='float'">fgpu_atof</xsl:when>
-      
-        <xsl:when test="$type='ivec2'">fpgu_strtol</xsl:when>
-        <xsl:when test="$type='uvec2'">fpgu_strtoul</xsl:when>
-        <xsl:when test="$type='fvec2'">fgpu_atof</xsl:when>
-        <xsl:when test="$type='dvec2'">fpgu_strtod</xsl:when>
-        
-        <xsl:when test="$type='ivec3'">fpgu_strtol</xsl:when>
-        <xsl:when test="$type='uvec3'">fpgu_strtoul</xsl:when>
-        <xsl:when test="$type='fvec3'">fgpu_atof</xsl:when>
-        <xsl:when test="$type='dvec3'">fpgu_strtod</xsl:when>
-      
-        <xsl:when test="$type='ivec4'">fpgu_strtol</xsl:when>
-        <xsl:when test="$type='uvec4'">fpgu_strtoul</xsl:when>
-        <xsl:when test="$type='fvec4'">fgpu_atof</xsl:when>
-        <xsl:when test="$type='dvec4'">fpgu_strtod</xsl:when>
-      
-        <xsl:otherwise>atof</xsl:otherwise> <!-- default parse function as float -->
-    </xsl:choose>
-</xsl:template>
-  
-  <!-- function pointer for reading variable types from string --> 
-<xsl:template name="vectorBaseType">
-    <xsl:param name="type"/>
-    <xsl:choose>        
-        <xsl:when test="$type='ivec2'">int</xsl:when>
-        <xsl:when test="$type='uvec2'">unsigned int</xsl:when>
-        <xsl:when test="$type='fvec2'">float</xsl:when>
-        <xsl:when test="$type='dvec2'">double</xsl:when>
-        
-        <xsl:when test="$type='ivec3'">int</xsl:when>
-        <xsl:when test="$type='uvec3'">unsigned int</xsl:when>
-        <xsl:when test="$type='fvec3'">float</xsl:when>
-        <xsl:when test="$type='dvec3'">double</xsl:when>
-      
-        <xsl:when test="$type='ivec4'">int</xsl:when>
-        <xsl:when test="$type='uvec4'">unsigned int</xsl:when>
-        <xsl:when test="$type='fvec4'">float</xsl:when>
-        <xsl:when test="$type='dvec4'">double</xsl:when>
-      
-        <xsl:otherwise>float</xsl:otherwise> <!-- default base type of float -->
-    </xsl:choose>
-</xsl:template>
-  
+<xsl:include href = "./_common_templates.xslt" />
 <xsl:template match="/">
-  
-/*
-* FLAME GPU v 1.5.X for CUDA 9
-* Copyright University of Sheffield.
-* Original Author: Dr Paul Richmond (user contributions tracked on https://github.com/FLAMEGPU/FLAMEGPU)
-* Contact: p.richmond@sheffield.ac.uk (http://www.paulrichmond.staff.shef.ac.uk)
-*
-* University of Sheffield retain all intellectual property and
-* proprietary rights in and to this software and related documentation.
-* Any use, reproduction, disclosure, or distribution of this software
-* and related documentation without an express license agreement from
-* University of Sheffield is strictly prohibited.
-*
-* For terms of licence agreement please attached licence or view licence
-* on www.flamegpu.com website.
-*
-*/
+<xsl:call-template name="copyrightNotice"></xsl:call-template>
 
 #include &lt;cuda_runtime.h&gt;
 #include &lt;stdlib.h&gt;
@@ -210,8 +28,8 @@ int fpgu_strtol(const char* str){
     return (int)strtol(str, NULL, 0);
 }
 
-unsigned long int fpgu_strtoul(const char* str){
-    return strtoul(str, NULL, 0);
+unsigned int fpgu_strtoul(const char* str){
+    return (unsigned int)strtoul(str, NULL, 0);
 }
 
 long long int fpgu_strtoll(const char* str){
@@ -445,9 +263,10 @@ void readInitialStates(char* inputpath, <xsl:for-each select="gpu:xmodel/xmml:xa
 
 	/* Default variables for memory */<xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent/xmml:memory/gpu:variable"><xsl:choose><xsl:when test="xmml:arrayLength">
     for (i=0;i&lt;<xsl:value-of select="xmml:arrayLength"/>;i++){
-        <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>[i] = <xsl:choose><xsl:when test="xmml:defaultValue"><xsl:value-of select="xmml:defaultValue"/></xsl:when><xsl:otherwise><xsl:call-template name="defaultInitialiser"><xsl:with-param name="type" select="xmml:type"/></xsl:call-template></xsl:otherwise></xsl:choose>;
+        <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>[i] = <xsl:call-template name="defaultInitialiser"><xsl:with-param name="type" select="xmml:type"/><xsl:with-param name="defaultValue" select="xmml:defaultValue" /></xsl:call-template>;
     }</xsl:when><xsl:otherwise><xsl:text>
-    </xsl:text><xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/> = <xsl:choose><xsl:when test="xmml:defaultValue"><xsl:value-of select="xmml:defaultValue"/></xsl:when><xsl:otherwise><xsl:call-template name="defaultInitialiser"><xsl:with-param name="type" select="xmml:type"/></xsl:call-template></xsl:otherwise></xsl:choose>;</xsl:otherwise></xsl:choose></xsl:for-each>
+    </xsl:text><xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/> = <xsl:call-template name="defaultInitialiser"><xsl:with-param name="type" select="xmml:type"/><xsl:with-param name="defaultValue" select="xmml:defaultValue" /></xsl:call-template>;</xsl:otherwise>
+    </xsl:choose></xsl:for-each>
 
     /* Default variables for environment variables */
     <xsl:for-each select="gpu:xmodel/gpu:environment/gpu:constants/gpu:variable"><xsl:choose><xsl:when test="xmml:arrayLength">
@@ -557,9 +376,9 @@ void readInitialStates(char* inputpath, <xsl:for-each select="gpu:xmodel/xmml:xa
 
 				/* Reset xagent variables */<xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent/xmml:memory/gpu:variable"><xsl:choose><xsl:when test="xmml:arrayLength">
                 for (i=0;i&lt;<xsl:value-of select="xmml:arrayLength"/>;i++){
-                    <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>[i] = <xsl:choose><xsl:when test="xmml:defaultValue"><xsl:value-of select="xmml:defaultValue"/></xsl:when><xsl:otherwise><xsl:call-template name="defaultInitialiser"><xsl:with-param name="type" select="xmml:type"/></xsl:call-template></xsl:otherwise></xsl:choose>;
+                    <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>[i] = <xsl:call-template name="defaultInitialiser"><xsl:with-param name="type" select="xmml:type"/><xsl:with-param name="defaultValue" select="xmml:defaultValue" /></xsl:call-template>;
                 }</xsl:when><xsl:otherwise><xsl:text>
-                </xsl:text><xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/> = <xsl:choose><xsl:when test="xmml:defaultValue"><xsl:value-of select="xmml:defaultValue"/></xsl:when><xsl:otherwise><xsl:call-template name="defaultInitialiser"><xsl:with-param name="type" select="xmml:type"/></xsl:call-template></xsl:otherwise></xsl:choose>;</xsl:otherwise></xsl:choose></xsl:for-each>
+                </xsl:text><xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/> = <xsl:call-template name="defaultInitialiser"><xsl:with-param name="type" select="xmml:type"/><xsl:with-param name="defaultValue" select="xmml:defaultValue" /></xsl:call-template>;</xsl:otherwise></xsl:choose></xsl:for-each>
                 
                 in_xagent = 0;
 			}
@@ -620,16 +439,35 @@ void readInitialStates(char* inputpath, <xsl:for-each select="gpu:xmodel/xmml:xa
             else if (in_env){
             <xsl:for-each select="gpu:xmodel/gpu:environment/gpu:constants/gpu:variable">if(in_env_<xsl:value-of select="xmml:name"/>){
               <xsl:choose>
-                <xsl:when test="xmml:arrayLength">
-                  //array input
-                  readArrayInput&lt;<xsl:value-of select="xmml:type"/>&gt;(&amp;<xsl:call-template name="typeParserFunc"><xsl:with-param name="type" select="xmml:type"/></xsl:call-template>, buffer, env_<xsl:value-of select="xmml:name"/>, <xsl:value-of select="xmml:arrayLength"/>); 
-                  set_<xsl:value-of select="xmml:name"/>(env_<xsl:value-of select="xmml:name"/>);</xsl:when>
-                <xsl:otherwise>
-                  //scalar value input
-                  env_<xsl:value-of select="xmml:name"/> = (<xsl:value-of select="xmml:type"/>) <xsl:call-template name="typeParserFunc"><xsl:with-param name="type" select="xmml:type"/></xsl:call-template>(buffer);
-                  set_<xsl:value-of select="xmml:name"/>(&amp;env_<xsl:value-of select="xmml:name"/>);
-                </xsl:otherwise>
-              </xsl:choose>  
+                  <xsl:when test="xmml:arrayLength">
+                    <!-- Specialise input reads for vector types -->
+                    <xsl:choose>
+                    <xsl:when test="contains(xmml:type, '2')">readArrayInputVectorType&lt;<xsl:value-of select="xmml:type"/>, <xsl:call-template name="vectorBaseType"><xsl:with-param name="type" select="xmml:type"/></xsl:call-template>, 2&gt;(&amp;<xsl:call-template name="typeParserFunc"><xsl:with-param name="type" select="xmml:type"/></xsl:call-template>, buffer, env_<xsl:value-of select="xmml:name"/>, <xsl:value-of select="xmml:arrayLength"/>);</xsl:when>
+                    <xsl:when test="contains(xmml:type, '3')">readArrayInputVectorType&lt;<xsl:value-of select="xmml:type"/>, <xsl:call-template name="vectorBaseType"><xsl:with-param name="type" select="xmml:type"/></xsl:call-template>, 3&gt;(&amp;<xsl:call-template name="typeParserFunc"><xsl:with-param name="type" select="xmml:type"/></xsl:call-template>, buffer, env_<xsl:value-of select="xmml:name"/>, <xsl:value-of select="xmml:arrayLength"/>);</xsl:when>
+                    <xsl:when test="contains(xmml:type, '4')">readArrayInputVectorType&lt;<xsl:value-of select="xmml:type"/>, <xsl:call-template name="vectorBaseType"><xsl:with-param name="type" select="xmml:type"/></xsl:call-template>, 4&gt;(&amp;<xsl:call-template name="typeParserFunc"><xsl:with-param name="type" select="xmml:type"/></xsl:call-template>, buffer, env_<xsl:value-of select="xmml:name"/>, <xsl:value-of select="xmml:arrayLength"/>);</xsl:when>
+                    <xsl:otherwise>readArrayInput&lt;<xsl:value-of select="xmml:type"/>&gt;(&amp;<xsl:call-template name="typeParserFunc"><xsl:with-param name="type" select="xmml:type"/></xsl:call-template>, buffer, env_<xsl:value-of select="xmml:name"/>, <xsl:value-of select="xmml:arrayLength"/>);</xsl:otherwise>
+                    </xsl:choose>
+                    set_<xsl:value-of select="xmml:name"/>(env_<xsl:value-of select="xmml:name"/>);
+                  </xsl:when>
+                  <xsl:otherwise>
+                    <!-- Specialise input reads for vector types -->
+                    <xsl:choose>
+                    <xsl:when test="contains(xmml:type, '2')">
+                      readArrayInput&lt;<xsl:call-template name="vectorBaseType"><xsl:with-param name="type" select="xmml:type"/></xsl:call-template>&gt;(&amp;<xsl:call-template name="typeParserFunc"><xsl:with-param name="type" select="xmml:type"/></xsl:call-template>, buffer, (<xsl:call-template name="vectorBaseType"><xsl:with-param name="type" select="xmml:type"/></xsl:call-template>*)&amp;env_<xsl:value-of select="xmml:name"/>, 2); 
+                    </xsl:when>
+                    <xsl:when test="contains(xmml:type, '3')">
+                      readArrayInput&lt;<xsl:call-template name="vectorBaseType"><xsl:with-param name="type" select="xmml:type"/></xsl:call-template>&gt;(&amp;<xsl:call-template name="typeParserFunc"><xsl:with-param name="type" select="xmml:type"/></xsl:call-template>, buffer, (<xsl:call-template name="vectorBaseType"><xsl:with-param name="type" select="xmml:type"/></xsl:call-template>*)&amp;env_<xsl:value-of select="xmml:name"/>, 3); 
+                    </xsl:when>
+                    <xsl:when test="contains(xmml:type, '4')">
+                      readArrayInput&lt;<xsl:call-template name="vectorBaseType"><xsl:with-param name="type" select="xmml:type"/></xsl:call-template>&gt;(&amp;<xsl:call-template name="typeParserFunc"><xsl:with-param name="type" select="xmml:type"/></xsl:call-template>, buffer, (<xsl:call-template name="vectorBaseType"><xsl:with-param name="type" select="xmml:type"/></xsl:call-template>*)&amp;env_<xsl:value-of select="xmml:name"/>, 4); 
+                    </xsl:when>
+                    <xsl:otherwise>
+                    env_<xsl:value-of select="xmml:name"/> = (<xsl:value-of select="xmml:type"/>) <xsl:call-template name="typeParserFunc"><xsl:with-param name="type" select="xmml:type"/></xsl:call-template>(buffer);
+                    </xsl:otherwise>
+                    </xsl:choose>
+                    set_<xsl:value-of select="xmml:name"/>(&amp;env_<xsl:value-of select="xmml:name"/>);
+                  </xsl:otherwise>
+                </xsl:choose>
               }
             </xsl:for-each>
           }

--- a/FLAMEGPU/templates/main.xslt
+++ b/FLAMEGPU/templates/main.xslt
@@ -3,23 +3,9 @@
                 xmlns:xmml="http://www.dcs.shef.ac.uk/~paul/XMML"
                 xmlns:gpu="http://www.dcs.shef.ac.uk/~paul/XMMLGPU">
 <xsl:output method="text" version="1.0" encoding="UTF-8" indent="yes" />
+<xsl:include href = "./_common_templates.xslt" />
 <xsl:template match="/">
-  /*
-  * FLAME GPU v 1.5.X for CUDA 9
-  * Copyright University of Sheffield.
-  * Original Author: Dr Paul Richmond (user contributions tracked on https://github.com/FLAMEGPU/FLAMEGPU)
-  * Contact: p.richmond@sheffield.ac.uk (http://www.paulrichmond.staff.shef.ac.uk)
-  *
-  * University of Sheffield retain all intellectual property and
-  * proprietary rights in and to this software and related documentation.
-  * Any use, reproduction, disclosure, or distribution of this software
-  * and related documentation without an express license agreement from
-  * University of Sheffield is strictly prohibited.
-  *
-  * For terms of licence agreement please attached licence or view licence
-  * on www.flamegpu.com website.
-  *
-  */
+<xsl:call-template name="copyrightNotice"></xsl:call-template>
   #include &lt;cuda_runtime.h&gt;
 #include &lt;stdio.h&gt;
 #include &lt;string.h&gt;

--- a/FLAMEGPU/templates/simulation.xslt
+++ b/FLAMEGPU/templates/simulation.xslt
@@ -3,44 +3,9 @@
                 xmlns:xmml="http://www.dcs.shef.ac.uk/~paul/XMML"
                 xmlns:gpu="http://www.dcs.shef.ac.uk/~paul/XMMLGPU">
 <xsl:output method="text" version="1.0" encoding="UTF-8" indent="yes" />
-<xsl:template name="defaultInitialiser">
-    <xsl:param name="type"/>
-    <xsl:choose>
-        <xsl:when test="$type='ivec2'">{0, 0}</xsl:when>
-        <xsl:when test="$type='uvec2'">{0, 0}</xsl:when>
-        <xsl:when test="$type='fvec2'">{0, 0}</xsl:when>
-        <xsl:when test="$type='dvec2'">{0, 0}</xsl:when>
-        
-        <xsl:when test="$type='ivec3'">{0, 0, 0}</xsl:when>
-        <xsl:when test="$type='uvec3'">{0, 0, 0}</xsl:when>
-        <xsl:when test="$type='fvec3'">{0, 0, 0}</xsl:when>
-        <xsl:when test="$type='dvec3'">{0, 0, 0}</xsl:when>
-        
-        <xsl:when test="$type='ivec4'">{0, 0, 0, 0}</xsl:when>
-        <xsl:when test="$type='uvec4'">{0, 0, 0, 0}</xsl:when>
-        <xsl:when test="$type='fvec4'">{0, 0, 0, 0}</xsl:when>
-        <xsl:when test="$type='dvec4'">{0, 0, 0, 0}</xsl:when>
-        
-        <xsl:otherwise>0</xsl:otherwise> <!-- default output format is float -->
-    </xsl:choose>
-</xsl:template> 
+<xsl:include href = "./_common_templates.xslt" />
 <xsl:template match="/">
-  /*
-  * FLAME GPU v 1.5.X for CUDA 9
-  * Copyright University of Sheffield.
-  * Original Author: Dr Paul Richmond (user contributions tracked on https://github.com/FLAMEGPU/FLAMEGPU)
-  * Contact: p.richmond@sheffield.ac.uk (http://www.paulrichmond.staff.shef.ac.uk)
-  *
-  * University of Sheffield retain all intellectual property and
-  * proprietary rights in and to this software and related documentation.
-  * Any use, reproduction, disclosure, or distribution of this software
-  * and related documentation without an express license agreement from
-  * University of Sheffield is strictly prohibited.
-  *
-  * For terms of licence agreement please attached licence or view licence
-  * on www.flamegpu.com website.
-  *
-  */
+<xsl:call-template name="copyrightNotice"></xsl:call-template>
 
   //Disable internal thrust warnings about conversions
   #ifdef _MSC_VER
@@ -110,6 +75,11 @@
 </xsl:for-each>
 </xsl:for-each>
 </xsl:for-each>
+
+<!--Compile time error if there are any messages with vector type variables-->
+<xsl:for-each select="gpu:xmodel/xmml:messages/gpu:message"><xsl:variable name="message_name" select="xmml:name"/><xsl:for-each select="xmml:variables/gpu:variable"><xsl:variable name="variable_name" select="xmml:name"/><xsl:variable name="variable_type" select="xmml:type"/><xsl:if test="contains($variable_type, 'vec')">
+#error "Message `<xsl:value-of select="$message_name" />` contains vector type message variable `<xsl:value-of select="$variable_name" />` of type `<xsl:value-of select="$variable_type" />`"
+</xsl:if></xsl:for-each></xsl:for-each>
 
 #ifdef _MSC_VER
 #pragma warning(pop)
@@ -937,13 +907,13 @@ xmachine_memory_<xsl:value-of select="$agent_name" />* h_allocate_agent_<xsl:val
     memset(agent, 0, sizeof(xmachine_memory_<xsl:value-of select="$agent_name" />));
 <xsl:for-each select="xmml:memory/gpu:variable">
 <xsl:if test="xmml:defaultValue and not(xmml:arrayLength)">
-    agent-&gt;<xsl:value-of select="xmml:name"/> = <xsl:value-of select="xmml:defaultValue"/>;
+    agent-&gt;<xsl:value-of select="xmml:name"/> = <xsl:call-template name="defaultInitialiser"><xsl:with-param name="type" select="xmml:type"/><xsl:with-param name="defaultValue" select="xmml:defaultValue" /></xsl:call-template>;
 </xsl:if>
 <xsl:if test="xmml:arrayLength">	// Agent variable arrays must be allocated
     agent-&gt;<xsl:value-of select="xmml:name"/> = (<xsl:value-of select="xmml:type"/>*)malloc(<xsl:value-of select="xmml:arrayLength"/> * sizeof(<xsl:value-of select="xmml:type"/>));
-	<xsl:choose><xsl:when test="xmml:defaultValue">// If we have a defauly value, set each element correctly.
+	<xsl:choose><xsl:when test="xmml:defaultValue">// If we have a default value, set each element correctly.
 	for(unsigned int index = 0; index &lt; <xsl:value-of select="xmml:arrayLength"/>; index++){
-		agent-&gt;<xsl:value-of select="xmml:name"/>[index] = (<xsl:value-of select="xmml:type"/>)<xsl:value-of select="xmml:defaultValue"/>;
+		agent-&gt;<xsl:value-of select="xmml:name"/>[index] = <xsl:call-template name="defaultInitialiser"><xsl:with-param name="type" select="xmml:type"/><xsl:with-param name="defaultValue" select="xmml:defaultValue" /></xsl:call-template>;
 	}</xsl:when><xsl:otherwise>
     // If there is no default value, memset to 0.
     memset(agent-&gt;<xsl:value-of select="xmml:name"/>, 0, sizeof(<xsl:value-of select="xmml:type"/>)*<xsl:value-of select="xmml:arrayLength"/>);</xsl:otherwise>

--- a/FLAMEGPU/templates/visualisation.xslt
+++ b/FLAMEGPU/templates/visualisation.xslt
@@ -3,26 +3,12 @@
                 xmlns:xmml="http://www.dcs.shef.ac.uk/~paul/XMML"
                 xmlns:gpu="http://www.dcs.shef.ac.uk/~paul/XMMLGPU">
 <xsl:output method="text" version="1.0" encoding="UTF-8" indent="yes" />
+<xsl:include href = "./_common_templates.xslt" />
 <xsl:template match="/">
-  /*
-  * FLAME GPU v 1.5.X for CUDA 9
-  * Copyright University of Sheffield.
-  * Original Author: Dr Paul Richmond (user contributions tracked on https://github.com/FLAMEGPU/FLAMEGPU)
-  * Contact: p.richmond@sheffield.ac.uk (http://www.paulrichmond.staff.shef.ac.uk)
-  *
-  * University of Sheffield retain all intellectual property and
-  * proprietary rights in and to this software and related documentation.
-  * Any use, reproduction, disclosure, or distribution of this software
-  * and related documentation without an express license agreement from
-  * University of Sheffield is strictly prohibited.
-  *
-  * For terms of licence agreement please attached licence or view licence
-  * on www.flamegpu.com website.
-  *
-  */
+<xsl:call-template name="copyrightNotice"></xsl:call-template>
 
-  // includes, project
-  #include &lt;cuda_runtime.h&gt;
+// includes, project
+#include &lt;cuda_runtime.h&gt;
 #include &lt;stdlib.h&gt;
 #include &lt;stdio.h&gt;
 #include &lt;string.h&gt;

--- a/examples/Analytics/Analytics.vcxproj
+++ b/examples/Analytics/Analytics.vcxproj
@@ -147,6 +147,7 @@ copy "$(CudaToolkitBinDir)\cudart*.dll" "$(OutDir)"</Command>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
+    <Xml Include="..\..\FLAMEGPU\templates\_common_templates.xslt" />
     <Xml Include="..\..\FLAMEGPU\templates\FLAMEGPU_kernals.xslt" />
     <Xml Include="..\..\FLAMEGPU\templates\header.xslt" />
     <Xml Include="..\..\FLAMEGPU\templates\io.xslt" />

--- a/examples/Analytics/Analytics.vcxproj.filters
+++ b/examples/Analytics/Analytics.vcxproj.filters
@@ -28,6 +28,9 @@
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
+    <Xml Include="..\..\FLAMEGPU\templates\_common_templates.xslt">
+      <Filter>templates</Filter>
+    </Xml>
     <Xml Include="..\..\FLAMEGPU\templates\FLAMEGPU_kernals.xslt">
       <Filter>templates</Filter>
     </Xml>

--- a/examples/Boids_BruteForce/Boids_BruteForce.vcxproj
+++ b/examples/Boids_BruteForce/Boids_BruteForce.vcxproj
@@ -246,6 +246,7 @@ copy "$(CudaToolkitBinDir)\cudart*.dll" "$(OutDir)"</Command>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
+    <Xml Include="..\..\FLAMEGPU\templates\_common_templates.xslt" />
     <Xml Include="..\..\FLAMEGPU\templates\FLAMEGPU_kernals.xslt" />
     <Xml Include="..\..\FLAMEGPU\templates\header.xslt" />
     <Xml Include="..\..\FLAMEGPU\templates\io.xslt" />

--- a/examples/Boids_BruteForce/Boids_BruteForce.vcxproj.filters
+++ b/examples/Boids_BruteForce/Boids_BruteForce.vcxproj.filters
@@ -28,6 +28,9 @@
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
+    <Xml Include="..\..\FLAMEGPU\templates\_common_templates.xslt">
+      <Filter>templates</Filter>
+    </Xml>
     <Xml Include="..\..\FLAMEGPU\templates\FLAMEGPU_kernals.xslt">
       <Filter>templates</Filter>
     </Xml>

--- a/examples/Boids_Partitioning/Boids_Partitioning.vcxproj
+++ b/examples/Boids_Partitioning/Boids_Partitioning.vcxproj
@@ -246,6 +246,7 @@ copy "$(CudaToolkitBinDir)\cudart*.dll" "$(OutDir)"</Command>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
+    <Xml Include="..\..\FLAMEGPU\templates\_common_templates.xslt" />
     <Xml Include="..\..\FLAMEGPU\templates\FLAMEGPU_kernals.xslt" />
     <Xml Include="..\..\FLAMEGPU\templates\header.xslt" />
     <Xml Include="..\..\FLAMEGPU\templates\io.xslt" />

--- a/examples/Boids_Partitioning/Boids_Partitioning.vcxproj.filters
+++ b/examples/Boids_Partitioning/Boids_Partitioning.vcxproj.filters
@@ -28,6 +28,9 @@
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
+    <Xml Include="..\..\FLAMEGPU\templates\_common_templates.xslt">
+      <Filter>templates</Filter>
+    </Xml>
     <Xml Include="..\..\FLAMEGPU\templates\FLAMEGPU_kernals.xslt">
       <Filter>templates</Filter>
     </Xml>

--- a/examples/Boids_PartitioningVecTypes/Boids_PartitioningVecTypes.vcxproj
+++ b/examples/Boids_PartitioningVecTypes/Boids_PartitioningVecTypes.vcxproj
@@ -246,6 +246,7 @@ copy "$(CudaToolkitBinDir)\cudart*.dll" "$(OutDir)"</Command>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
+    <Xml Include="..\..\FLAMEGPU\templates\_common_templates.xslt" />
     <Xml Include="..\..\FLAMEGPU\templates\FLAMEGPU_kernals.xslt" />
     <Xml Include="..\..\FLAMEGPU\templates\header.xslt" />
     <Xml Include="..\..\FLAMEGPU\templates\io.xslt" />

--- a/examples/Boids_PartitioningVecTypes/Boids_PartitioningVecTypes.vcxproj.filters
+++ b/examples/Boids_PartitioningVecTypes/Boids_PartitioningVecTypes.vcxproj.filters
@@ -28,6 +28,9 @@
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
+    <Xml Include="..\..\FLAMEGPU\templates\_common_templates.xslt">
+      <Filter>templates</Filter>
+    </Xml>
     <Xml Include="..\..\FLAMEGPU\templates\FLAMEGPU_kernals.xslt">
       <Filter>templates</Filter>
     </Xml>

--- a/examples/CirclesBruteForce_double/CirclesBruteForce_double.vcxproj
+++ b/examples/CirclesBruteForce_double/CirclesBruteForce_double.vcxproj
@@ -147,6 +147,7 @@ copy "$(CudaToolkitBinDir)\cudart*.dll" "$(OutDir)"</Command>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
+    <Xml Include="..\..\FLAMEGPU\templates\_common_templates.xslt" />
     <Xml Include="..\..\FLAMEGPU\templates\FLAMEGPU_kernals.xslt" />
     <Xml Include="..\..\FLAMEGPU\templates\header.xslt" />
     <Xml Include="..\..\FLAMEGPU\templates\io.xslt" />

--- a/examples/CirclesBruteForce_double/CirclesBruteForce_double.vcxproj.filters
+++ b/examples/CirclesBruteForce_double/CirclesBruteForce_double.vcxproj.filters
@@ -28,6 +28,9 @@
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
+    <Xml Include="..\..\FLAMEGPU\templates\_common_templates.xslt">
+      <Filter>templates</Filter>
+    </Xml>
     <Xml Include="..\..\FLAMEGPU\templates\FLAMEGPU_kernals.xslt">
       <Filter>templates</Filter>
     </Xml>

--- a/examples/CirclesBruteForce_float/CirclesBruteForce_float.vcxproj
+++ b/examples/CirclesBruteForce_float/CirclesBruteForce_float.vcxproj
@@ -147,6 +147,7 @@ copy "$(CudaToolkitBinDir)\cudart*.dll" "$(OutDir)"</Command>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
+    <Xml Include="..\..\FLAMEGPU\templates\_common_templates.xslt" />
     <Xml Include="..\..\FLAMEGPU\templates\FLAMEGPU_kernals.xslt" />
     <Xml Include="..\..\FLAMEGPU\templates\header.xslt" />
     <Xml Include="..\..\FLAMEGPU\templates\io.xslt" />

--- a/examples/CirclesBruteForce_float/CirclesBruteForce_float.vcxproj.filters
+++ b/examples/CirclesBruteForce_float/CirclesBruteForce_float.vcxproj.filters
@@ -28,6 +28,9 @@
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
+    <Xml Include="..\..\FLAMEGPU\templates\_common_templates.xslt">
+      <Filter>templates</Filter>
+    </Xml>
     <Xml Include="..\..\FLAMEGPU\templates\FLAMEGPU_kernals.xslt">
       <Filter>templates</Filter>
     </Xml>

--- a/examples/CirclesPartitioning_double/CirclesPartitioning_double.vcxproj
+++ b/examples/CirclesPartitioning_double/CirclesPartitioning_double.vcxproj
@@ -147,6 +147,7 @@ copy "$(CudaToolkitBinDir)\cudart*.dll" "$(OutDir)"</Command>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
+    <Xml Include="..\..\FLAMEGPU\templates\_common_templates.xslt" />
     <Xml Include="..\..\FLAMEGPU\templates\FLAMEGPU_kernals.xslt" />
     <Xml Include="..\..\FLAMEGPU\templates\header.xslt" />
     <Xml Include="..\..\FLAMEGPU\templates\io.xslt" />

--- a/examples/CirclesPartitioning_double/CirclesPartitioning_double.vcxproj.filters
+++ b/examples/CirclesPartitioning_double/CirclesPartitioning_double.vcxproj.filters
@@ -28,6 +28,9 @@
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
+    <Xml Include="..\..\FLAMEGPU\templates\_common_templates.xslt">
+      <Filter>templates</Filter>
+    </Xml>
     <Xml Include="..\..\FLAMEGPU\templates\FLAMEGPU_kernals.xslt">
       <Filter>templates</Filter>
     </Xml>

--- a/examples/CirclesPartitioning_float/CirclesPartitioning_float.vcxproj
+++ b/examples/CirclesPartitioning_float/CirclesPartitioning_float.vcxproj
@@ -147,6 +147,7 @@ copy "$(CudaToolkitBinDir)\cudart*.dll" "$(OutDir)"</Command>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
+    <Xml Include="..\..\FLAMEGPU\templates\_common_templates.xslt" />
     <Xml Include="..\..\FLAMEGPU\templates\FLAMEGPU_kernals.xslt" />
     <Xml Include="..\..\FLAMEGPU\templates\header.xslt" />
     <Xml Include="..\..\FLAMEGPU\templates\io.xslt" />

--- a/examples/CirclesPartitioning_float/CirclesPartitioning_float.vcxproj.filters
+++ b/examples/CirclesPartitioning_float/CirclesPartitioning_float.vcxproj.filters
@@ -28,6 +28,9 @@
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
+    <Xml Include="..\..\FLAMEGPU\templates\_common_templates.xslt">
+      <Filter>templates</Filter>
+    </Xml>
     <Xml Include="..\..\FLAMEGPU\templates\FLAMEGPU_kernals.xslt">
       <Filter>templates</Filter>
     </Xml>

--- a/examples/EmptyExample/EmptyExample.vcxproj
+++ b/examples/EmptyExample/EmptyExample.vcxproj
@@ -246,6 +246,7 @@ copy "$(CudaToolkitBinDir)\cudart*.dll" "$(OutDir)"</Command>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
+    <Xml Include="..\..\FLAMEGPU\templates\_common_templates.xslt" />
     <Xml Include="..\..\FLAMEGPU\templates\FLAMEGPU_kernals.xslt" />
     <Xml Include="..\..\FLAMEGPU\templates\header.xslt" />
     <Xml Include="..\..\FLAMEGPU\templates\io.xslt" />

--- a/examples/EmptyExample/EmptyExample.vcxproj.filters
+++ b/examples/EmptyExample/EmptyExample.vcxproj.filters
@@ -28,6 +28,9 @@
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
+    <Xml Include="..\..\FLAMEGPU\templates\_common_templates.xslt">
+      <Filter>templates</Filter>
+    </Xml>
     <Xml Include="..\..\FLAMEGPU\templates\FLAMEGPU_kernals.xslt">
       <Filter>templates</Filter>
     </Xml>

--- a/examples/GameOfLife/GameOfLife.vcxproj
+++ b/examples/GameOfLife/GameOfLife.vcxproj
@@ -246,6 +246,7 @@ copy "$(CudaToolkitBinDir)\cudart*.dll" "$(OutDir)"</Command>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
+    <Xml Include="..\..\FLAMEGPU\templates\_common_templates.xslt" />
     <Xml Include="..\..\FLAMEGPU\templates\FLAMEGPU_kernals.xslt" />
     <Xml Include="..\..\FLAMEGPU\templates\header.xslt" />
     <Xml Include="..\..\FLAMEGPU\templates\io.xslt" />

--- a/examples/GameOfLife/GameOfLife.vcxproj.filters
+++ b/examples/GameOfLife/GameOfLife.vcxproj.filters
@@ -28,6 +28,9 @@
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
+    <Xml Include="..\..\FLAMEGPU\templates\_common_templates.xslt">
+      <Filter>templates</Filter>
+    </Xml>
     <Xml Include="..\..\FLAMEGPU\templates\FLAMEGPU_kernals.xslt">
       <Filter>templates</Filter>
     </Xml>

--- a/examples/HostAgentCreation/HostAgentCreation.vcxproj
+++ b/examples/HostAgentCreation/HostAgentCreation.vcxproj
@@ -149,6 +149,7 @@ copy "$(CudaToolkitBinDir)\cudart*.dll" "$(OutDir)"</Command>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
+    <Xml Include="..\..\FLAMEGPU\templates\_common_templates.xslt" />
     <Xml Include="..\..\FLAMEGPU\templates\FLAMEGPU_kernals.xslt" />
     <Xml Include="..\..\FLAMEGPU\templates\header.xslt" />
     <Xml Include="..\..\FLAMEGPU\templates\io.xslt" />

--- a/examples/HostAgentCreation/HostAgentCreation.vcxproj.filters
+++ b/examples/HostAgentCreation/HostAgentCreation.vcxproj.filters
@@ -28,6 +28,9 @@
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
+    <Xml Include="..\..\FLAMEGPU\templates\_common_templates.xslt">
+      <Filter>templates</Filter>
+    </Xml>
     <Xml Include="..\..\FLAMEGPU\templates\FLAMEGPU_kernals.xslt">
       <Filter>templates</Filter>
     </Xml>

--- a/examples/Keratinocyte/Keratinocyte.vcxproj
+++ b/examples/Keratinocyte/Keratinocyte.vcxproj
@@ -246,6 +246,7 @@ copy "$(CudaToolkitBinDir)\cudart*.dll" "$(OutDir)"</Command>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
+    <Xml Include="..\..\FLAMEGPU\templates\_common_templates.xslt" />
     <Xml Include="..\..\FLAMEGPU\templates\FLAMEGPU_kernals.xslt" />
     <Xml Include="..\..\FLAMEGPU\templates\header.xslt" />
     <Xml Include="..\..\FLAMEGPU\templates\io.xslt" />

--- a/examples/Keratinocyte/Keratinocyte.vcxproj.filters
+++ b/examples/Keratinocyte/Keratinocyte.vcxproj.filters
@@ -28,6 +28,9 @@
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
+    <Xml Include="..\..\FLAMEGPU\templates\_common_templates.xslt">
+      <Filter>templates</Filter>
+    </Xml>
     <Xml Include="..\..\FLAMEGPU\templates\FLAMEGPU_kernals.xslt">
       <Filter>templates</Filter>
     </Xml>

--- a/examples/MonteCarlo_BATCH/MCBatch.vcxproj
+++ b/examples/MonteCarlo_BATCH/MCBatch.vcxproj
@@ -246,6 +246,7 @@ copy "$(CudaToolkitBinDir)\cudart*.dll" "$(OutDir)"</Command>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
+    <Xml Include="..\..\FLAMEGPU\templates\_common_templates.xslt" />
     <Xml Include="..\..\FLAMEGPU\templates\FLAMEGPU_kernals.xslt" />
     <Xml Include="..\..\FLAMEGPU\templates\header.xslt" />
     <Xml Include="..\..\FLAMEGPU\templates\io.xslt" />

--- a/examples/MonteCarlo_BATCH/MCBatch.vcxproj.filters
+++ b/examples/MonteCarlo_BATCH/MCBatch.vcxproj.filters
@@ -28,6 +28,9 @@
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
+    <Xml Include="..\..\FLAMEGPU\templates\_common_templates.xslt">
+      <Filter>templates</Filter>
+    </Xml>
     <Xml Include="..\..\FLAMEGPU\templates\FLAMEGPU_kernals.xslt">
       <Filter>templates</Filter>
     </Xml>

--- a/examples/MonteCarlo_MSMPR/MC_MSMPR.vcxproj
+++ b/examples/MonteCarlo_MSMPR/MC_MSMPR.vcxproj
@@ -246,6 +246,7 @@ copy "$(CudaToolkitBinDir)\cudart*.dll" "$(OutDir)"</Command>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
+    <Xml Include="..\..\FLAMEGPU\templates\_common_templates.xslt" />
     <Xml Include="..\..\FLAMEGPU\templates\FLAMEGPU_kernals.xslt" />
     <Xml Include="..\..\FLAMEGPU\templates\header.xslt" />
     <Xml Include="..\..\FLAMEGPU\templates\io.xslt" />

--- a/examples/MonteCarlo_MSMPR/MC_MSMPR.vcxproj.filters
+++ b/examples/MonteCarlo_MSMPR/MC_MSMPR.vcxproj.filters
@@ -28,6 +28,9 @@
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
+    <Xml Include="..\..\FLAMEGPU\templates\_common_templates.xslt">
+      <Filter>templates</Filter>
+    </Xml>
     <Xml Include="..\..\FLAMEGPU\templates\FLAMEGPU_kernals.xslt">
       <Filter>templates</Filter>
     </Xml>

--- a/examples/PedestrianLOD/PedestrianLOD.vcxproj
+++ b/examples/PedestrianLOD/PedestrianLOD.vcxproj
@@ -309,6 +309,7 @@ copy "$(CudaToolkitBinDir)\cudart*.dll" "$(OutDir)"</Command>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
+    <Xml Include="..\..\FLAMEGPU\templates\_common_templates.xslt" />
     <Xml Include="..\..\FLAMEGPU\templates\FLAMEGPU_kernals.xslt" />
     <Xml Include="..\..\FLAMEGPU\templates\header.xslt" />
     <Xml Include="..\..\FLAMEGPU\templates\io.xslt" />

--- a/examples/PedestrianLOD/PedestrianLOD.vcxproj.filters
+++ b/examples/PedestrianLOD/PedestrianLOD.vcxproj.filters
@@ -52,6 +52,9 @@
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
+    <Xml Include="..\..\FLAMEGPU\templates\_common_templates.xslt">
+      <Filter>templates</Filter>
+    </Xml>
     <Xml Include="..\..\FLAMEGPU\templates\FLAMEGPU_kernals.xslt">
       <Filter>templates</Filter>
     </Xml>

--- a/examples/PedestrianNavigation/PedestrianNavigation.vcxproj
+++ b/examples/PedestrianNavigation/PedestrianNavigation.vcxproj
@@ -321,6 +321,7 @@ copy "$(CudaToolkitBinDir)\cudart*.dll" "$(OutDir)"</Command>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
+    <Xml Include="..\..\FLAMEGPU\templates\_common_templates.xslt" />
     <Xml Include="..\..\FLAMEGPU\templates\FLAMEGPU_kernals.xslt">
       <SubType>Designer</SubType>
     </Xml>

--- a/examples/PedestrianNavigation/PedestrianNavigation.vcxproj.filters
+++ b/examples/PedestrianNavigation/PedestrianNavigation.vcxproj.filters
@@ -58,6 +58,9 @@
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
+    <Xml Include="..\..\FLAMEGPU\templates\_common_templates.xslt">
+      <Filter>templates</Filter>
+    </Xml>
     <Xml Include="..\..\FLAMEGPU\templates\FLAMEGPU_kernals.xslt">
       <Filter>templates</Filter>
     </Xml>

--- a/examples/StableMarriage/StableMarriage.vcxproj
+++ b/examples/StableMarriage/StableMarriage.vcxproj
@@ -147,6 +147,7 @@ copy "$(CudaToolkitBinDir)\cudart*.dll" "$(OutDir)"</Command>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
+    <Xml Include="..\..\FLAMEGPU\templates\_common_templates.xslt" />
     <Xml Include="..\..\FLAMEGPU\templates\FLAMEGPU_kernals.xslt" />
     <Xml Include="..\..\FLAMEGPU\templates\header.xslt" />
     <Xml Include="..\..\FLAMEGPU\templates\io.xslt" />

--- a/examples/StableMarriage/StableMarriage.vcxproj.filters
+++ b/examples/StableMarriage/StableMarriage.vcxproj.filters
@@ -28,6 +28,9 @@
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
+    <Xml Include="..\..\FLAMEGPU\templates\_common_templates.xslt">
+      <Filter>templates</Filter>
+    </Xml>
     <Xml Include="..\..\FLAMEGPU\templates\FLAMEGPU_kernals.xslt">
       <Filter>templates</Filter>
     </Xml>

--- a/examples/Sugarscape/Sugarscape.vcxproj
+++ b/examples/Sugarscape/Sugarscape.vcxproj
@@ -246,6 +246,7 @@ copy "$(CudaToolkitBinDir)\cudart*.dll" "$(OutDir)"</Command>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
+    <Xml Include="..\..\FLAMEGPU\templates\_common_templates.xslt" />
     <Xml Include="..\..\FLAMEGPU\templates\FLAMEGPU_kernals.xslt" />
     <Xml Include="..\..\FLAMEGPU\templates\header.xslt" />
     <Xml Include="..\..\FLAMEGPU\templates\io.xslt" />

--- a/examples/Sugarscape/Sugarscape.vcxproj.filters
+++ b/examples/Sugarscape/Sugarscape.vcxproj.filters
@@ -28,6 +28,9 @@
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
+    <Xml Include="..\..\FLAMEGPU\templates\_common_templates.xslt">
+      <Filter>templates</Filter>
+    </Xml>
     <Xml Include="..\..\FLAMEGPU\templates\FLAMEGPU_kernals.xslt">
       <Filter>templates</Filter>
     </Xml>

--- a/tools/common.mk
+++ b/tools/common.mk
@@ -277,6 +277,7 @@ VISUALISATION_DEPENDANCIES := $(BUILD_DIR)/io.cu$(OBJ_EXT) $(BUILD_DIR)/simulati
 endif
 
 XSLT_FUNCTIONS_C := $(SRC_DYNAMIC)/functions.c.tmp
+XSLT_COMMON_TEMPLATES := $(TEMPLATES_DIR)/_common_templates.xslt
 
 # Build target for less xmllint validation
 LAST_VALID_AT := $(BUILD_DIR)/.last_valid_at
@@ -334,7 +335,7 @@ visualisation: makedirs validate $(TARGET_VISUALISATION)
 endif
 
 # Rule to create header.h from XSLT. Depends upon both header.xslt and the XML file, so if either is changed a re-build will occur.
-$(SRC_DYNAMIC)/%.h: $(TEMPLATES_DIR)/%.xslt $(XML_MODEL_FILE)  $(MAKEFILE_LIST)
+$(SRC_DYNAMIC)/%.h: $(TEMPLATES_DIR)/%.xslt $(XML_MODEL_FILE) $(XSLT_COMMON_TEMPLATES) $(MAKEFILE_LIST)
 # Error if XSLTPROC is not available
 ifndef XSLTPROC
 	$(error "xsltproc is not available, please install xlstproc")
@@ -357,7 +358,7 @@ else
 endif
 
 # Rule to create *.cu files in the dynamic folder, as requested by build dependencies.
-$(SRC_DYNAMIC)/%.cu: $(TEMPLATES_DIR)/%.xslt $(XML_MODEL_FILE) $(MAKEFILE_LIST)
+$(SRC_DYNAMIC)/%.cu: $(TEMPLATES_DIR)/%.xslt $(XML_MODEL_FILE) $(XSLT_COMMON_TEMPLATES) $(MAKEFILE_LIST)
 # Error if XSLTPROC is not available
 ifndef XSLTPROC
 	$(error "xsltproc is not available, please install xlstproc")
@@ -380,7 +381,7 @@ else
 endif
 
 # Rule to create functsion.c file in the dynamic folder.
-$(SRC_DYNAMIC)/%.c.tmp: $(TEMPLATES_DIR)/%.xslt $(XML_MODEL_FILE) $(MAKEFILE_LIST)
+$(SRC_DYNAMIC)/%.c.tmp: $(TEMPLATES_DIR)/%.xslt $(XML_MODEL_FILE) $(XSLT_COMMON_TEMPLATES) $(MAKEFILE_LIST)
 # Error if XSLTPROC is not available
 ifndef XSLTPROC
 	$(error "xsltproc is not available, please install xlstproc")


### PR DESCRIPTION
This includes:
+ Explicitly blocking vector type variables for messages
+ Splitting common xslt template elements into a new XSLT file
+ Updating the makefile to depend on the common template rules
+ Using a regular expression to allow default values of:
    + Integers
    + Reals (with or without a trailing f)
    + Comma separated lists of numbers for vector types

This does **not** check that the value is correct for the specified type, only that the value is correct for one of the specified types

Visual studio project files need updating to become aware of the common template rules

Closes #191

## @todo before merge
+ [x] Update visual studio project files to include `_common_templates.xslt`