### PR TITLE
Rc1.5/discrete agent brute force messages

### DIFF
--- a/FLAMEGPU/templates/functions.xslt
+++ b/FLAMEGPU/templates/functions.xslt
@@ -66,14 +66,14 @@ __FLAME_GPU_EXIT_FUNC__ void <xsl:value-of select="gpu:name"/>(){
  <xsl:if test="xmml:xagentOutputs/gpu:xagentOutput">* @param <xsl:value-of select="xmml:xagentOutputs/gpu:xagentOutput/xmml:xagentName"/>_agents Pointer to agent list of type xmachine_memory_<xsl:value-of select="xmml:xagentOutputs/gpu:xagentOutput/xmml:xagentName"/>_list. This must be passed as an argument to the add_<xsl:value-of select="xmml:xagentOutputs/gpu:xagentOutput/xmml:xagentName"/>_agent function to add a new agent.</xsl:if>
  <xsl:if test="xmml:inputs/gpu:input"><xsl:variable name="messagename" select="xmml:inputs/gpu:input/xmml:messageName"/>* @param <xsl:value-of select="$messagename"/>_messages  <xsl:value-of select="xmml:inputs/gpu:input/xmml:messageName"/>_messages Pointer to input message list of type xmachine_message_<xsl:value-of select="xmml:inputs/gpu:inputs/xmml:messageName"/>_list. Must be passed as an argument to the get_first_<xsl:value-of select="xmml:inputs/gpu:input/xmml:messageName"/>_message and get_next_<xsl:value-of select="xmml:inputs/gpu:input/xmml:messageName"/>_message functions.<xsl:for-each select="../../../../xmml:messages/gpu:message[xmml:name=$messagename]">
  <xsl:if test="gpu:partitioningSpatial">* @param partition_matrix Pointer to the partition matrix of type xmachine_message_<xsl:value-of select="xmml:name"/>_PBM. Used within the get_first_<xsl:value-of select="xmml:inputs/gpu:input/xmml:messageName"/>_message and get_next_<xsl:value-of select="xmml:inputs/gpu:input/xmml:messageName"/>_message functions for spatially partitioned message access.</xsl:if></xsl:for-each></xsl:if>
- <xsl:if test="xmml:outputs/gpu:output">* @param <xsl:value-of select="xmml:outputs/gpu:output/xmml:messageName"/>_messages Pointer to output message list of type xmachine_message_<xsl:value-of select="xmml:outputs/gpu:output/xmml:messageName"/>_list. Must be passed as an argument to the add_<xsl:value-of select="xmml:outputs/gpu:output/xmml:messageName"/>_message function ??.</xsl:if>
+ <xsl:if test="xmml:outputs/gpu:output">* @param <xsl:value-of select="xmml:outputs/gpu:output/xmml:messageName"/>_messages Pointer to output message list of type xmachine_message_<xsl:value-of select="xmml:outputs/gpu:output/xmml:messageName"/>_list. Must be passed as an argument to the add_<xsl:value-of select="xmml:outputs/gpu:output/xmml:messageName"/>_message function.</xsl:if>
  <xsl:if test="gpu:RNG='true'">* @param rand48 Pointer to the seed list of type RNG_rand48. Must be passed as an argument to the rand48 function for generating random numbers on the GPU.</xsl:if>
  */
 __FLAME_GPU_FUNC__ int <xsl:value-of select="xmml:name"/>(xmachine_memory_<xsl:value-of select="../../xmml:name"/>* agent<xsl:if test="xmml:xagentOutputs/gpu:xagentOutput">, xmachine_memory_<xsl:value-of select="xmml:xagentOutputs/gpu:xagentOutput/xmml:xagentName"/>_list* <xsl:value-of select="xmml:xagentOutputs/gpu:xagentOutput/xmml:xagentName"/>_agents</xsl:if>
 <xsl:if test="xmml:inputs/gpu:input"><xsl:variable name="messagename" select="xmml:inputs/gpu:input/xmml:messageName"/>, xmachine_message_<xsl:value-of select="xmml:inputs/gpu:input/xmml:messageName"/>_list* <xsl:value-of select="xmml:inputs/gpu:input/xmml:messageName"/>_messages<xsl:for-each select="../../../../xmml:messages/gpu:message[xmml:name=$messagename]"><xsl:if test="gpu:partitioningSpatial">, xmachine_message_<xsl:value-of select="xmml:name"/>_PBM* partition_matrix</xsl:if></xsl:for-each></xsl:if>
 <xsl:if test="xmml:outputs/gpu:output">, xmachine_message_<xsl:value-of select="xmml:outputs/gpu:output/xmml:messageName"/>_list* <xsl:value-of select="xmml:outputs/gpu:output/xmml:messageName"/>_messages</xsl:if>
 <xsl:if test="gpu:RNG='true'">, RNG_rand48* rand48</xsl:if>){
-
+    <xsl:variable name="agent_type" select="../../gpu:type" />
     <xsl:if test="xmml:inputs/gpu:input">
     <xsl:variable name="messagename" select="xmml:inputs/gpu:input/xmml:messageName"/>
         <xsl:for-each select="../../../../xmml:messages/gpu:message[xmml:name=$messagename]">
@@ -88,22 +88,23 @@ __FLAME_GPU_FUNC__ int <xsl:value-of select="xmml:name"/>(xmachine_memory_<xsl:v
     float agent_z = 0.0;
     </xsl:if>
     //Template for input message iteration
-    xmachine_message_<xsl:value-of select="$messagename"/>* current_message = get_first_<xsl:value-of select="$messagename"/>_message(<xsl:value-of select="$messagename"/>_messages<xsl:if test="gpu:partitioningSpatial">, partition_matrix, agent_x, agent_y, agent_z</xsl:if><xsl:if test="gpu:partitioningDiscrete">, agent_x, agent_y</xsl:if>);
+    xmachine_message_<xsl:value-of select="$messagename"/>* current_message = get_first_<xsl:value-of select="$messagename"/>_message<xsl:if test="gpu:partitioningDiscrete">&lt;<xsl:if test="$agent_type='continuous'">CONTINUOUS</xsl:if><xsl:if test="$agent_type='discrete'">DISCRETE_2D</xsl:if>&gt;</xsl:if>(<xsl:value-of select="$messagename"/>_messages<xsl:if test="gpu:partitioningSpatial">, partition_matrix, agent_x, agent_y, agent_z</xsl:if><xsl:if test="gpu:partitioningDiscrete">, agent_x, agent_y</xsl:if>);
     while (current_message)
     {
         //INSERT MESSAGE PROCESSING CODE HERE
         
-        current_message = get_next_<xsl:value-of select="$messagename"/>_message(current_message, <xsl:value-of select="$messagename"/>_messages<xsl:if test="gpu:partitioningSpatial">, partition_matrix</xsl:if>);
+        current_message = get_next_<xsl:value-of select="$messagename"/>_message<xsl:if test="gpu:partitioningDiscrete">&lt;<xsl:if test="$agent_type='continuous'">CONTINUOUS</xsl:if><xsl:if test="$agent_type='discrete'">DISCRETE_2D</xsl:if>&gt;</xsl:if>(current_message, <xsl:value-of select="$messagename"/>_messages<xsl:if test="gpu:partitioningSpatial">, partition_matrix</xsl:if>);
     }
     */
     </xsl:for-each></xsl:if><xsl:if test="xmml:outputs/gpu:output">
     /* 
     //Template for message output function
-    <xsl:variable name="messagename" select="xmml:outputs/gpu:output/ xmml:messageName"/>
+    <xsl:variable name="messagename" select="xmml:outputs/gpu:output/xmml:messageName"/>
     <xsl:for-each select="../../../../xmml:messages/gpu:message[xmml:name=$messagename]/xmml:variables/gpu:variable">
     <xsl:value-of select="xmml:type"/><xsl:text> </xsl:text><xsl:value-of select="xmml:name"/> = 0;
     </xsl:for-each>
-    add_<xsl:value-of select="xmml:outputs/gpu:output/xmml:messageName"/>_message(<xsl:value-of select="xmml:outputs/gpu:output/xmml:messageName"/>_messages, <xsl:for-each select="../../../../xmml:messages/gpu:message[xmml:name=$messagename]/xmml:variables/gpu:variable"><xsl:value-of select="xmml:name"/><xsl:if test="position()!=last()">, </xsl:if></xsl:for-each>);
+    <xsl:variable name="isDiscretePartitioned" select="../../../../xmml:messages/gpu:message[xmml:name=$messagename]/gpu:partitioningDiscrete" />
+    add_<xsl:value-of select="$messagename"/>_message<xsl:if test="$isDiscretePartitioned">&lt;<xsl:if test="$agent_type='discrete'">DISCRETE_2D</xsl:if>&gt;</xsl:if>(<xsl:value-of select="xmml:outputs/gpu:output/xmml:messageName"/>_messages, <xsl:for-each select="../../../../xmml:messages/gpu:message[xmml:name=$messagename]/xmml:variables/gpu:variable"><xsl:value-of select="xmml:name"/><xsl:if test="position()!=last()">, </xsl:if></xsl:for-each>);
     */     
     </xsl:if><xsl:if test="xmml:xagentOutputs/gpu:xagentOutput">
     /* 

--- a/FLAMEGPU/templates/simulation.xslt
+++ b/FLAMEGPU/templates/simulation.xslt
@@ -93,6 +93,23 @@
 </xsl:if>
 </xsl:for-each>
 
+<!-- Compile time errors based on message partitioning and agent types-->
+<xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent"><xsl:variable name="agent_name" select="xmml:name"/><xsl:variable name="agent_type" select="gpu:type"/>
+<xsl:for-each select="xmml:functions/gpu:function"><xsl:variable name="function_name" select="xmml:name"/>
+<xsl:for-each select="xmml:outputs/gpu:output"><xsl:variable name="message_name" select="xmml:messageName"/>
+<xsl:for-each select="../../../../../../xmml:messages/gpu:message[xmml:name=$message_name]">
+<!-- Discrete agents can only output discrete messages -->
+<xsl:if test="$agent_type='discrete' and not(gpu:partitioningDiscrete)">
+#error "Discrete agent `<xsl:value-of select="$agent_name"/>` can only output partitioningDiscrete messages. `<xsl:value-of select="$message_name"/>` output by `<xsl:value-of select="$function_name"/>` are not partitioningDiscrete. "
+</xsl:if>
+<!-- Continous agents cannot output discrete messages -->
+<xsl:if test="$agent_type='continuous' and gpu:partitioningDiscrete">
+#error "Continuous agent `<xsl:value-of select="$agent_name"/>` cannot output partitioningDiscrete messages. `<xsl:value-of select="$message_name"/>` output by `<xsl:value-of select="$function_name"/>` are partitioningDiscrete. "
+</xsl:if>
+</xsl:for-each>
+</xsl:for-each>
+</xsl:for-each>
+</xsl:for-each>
 
 #ifdef _MSC_VER
 #pragma warning(pop)


### PR DESCRIPTION
+ Explicitly error when:
    + `continuous` agents have function(s) which output `discretePartitioned` messages
    + `discrete` agents have functions(s) which output `not(discretePartitioned)` messages 
+ Add appropriate templating `<CONTINUOUS>` or `<DISCRETE_2D>` to `functions.xslt` template for `get_first_*`, `get_next_*` and `add_*` discrete message functions.

Closes #216 