### PR TITLE
Hpc fixes

### DIFF
--- a/FLAMEGPU/templates/header.xslt
+++ b/FLAMEGPU/templates/header.xslt
@@ -11,7 +11,7 @@
 #ifndef __HEADER
 #define __HEADER
 
-#if defined __NVCC__
+#if defined(__NVCC__) &amp;&amp; CUDA_VERSION >= 9000
    // Disable annotation on defaulted function warnings (glm 0.9.9 and CUDA 9.0 introduced this warning)
    #pragma diag_suppress esa_on_defaulted_function_ignored 
 #endif

--- a/bin/linux-x64/Boids_BruteForce_console.sh
+++ b/bin/linux-x64/Boids_BruteForce_console.sh
@@ -1,1 +1,3 @@
+#!/bin/bash
+cd $(dirname "$BASH_SOURCE")
 ./Release_Console/Boids_BruteForce "../../examples/Boids_BruteForce/iterations/0.xml" 1

--- a/bin/linux-x64/Boids_BruteForce_visualisation.sh
+++ b/bin/linux-x64/Boids_BruteForce_visualisation.sh
@@ -1,1 +1,3 @@
+#!/bin/bash
+cd $(dirname "$BASH_SOURCE")
 ./Release_Visualisation/Boids_BruteForce "../../examples/Boids_BruteForce/iterations/0.xml"

--- a/bin/linux-x64/Boids_Partitioning_console.sh
+++ b/bin/linux-x64/Boids_Partitioning_console.sh
@@ -1,1 +1,3 @@
+#!/bin/bash
+cd $(dirname "$BASH_SOURCE")
 ./Release_Console/Boids_Partitioning "../../examples/Boids_Partitioning/iterations/0.xml" 1

--- a/bin/linux-x64/Boids_Partitioning_visualisation.sh
+++ b/bin/linux-x64/Boids_Partitioning_visualisation.sh
@@ -1,1 +1,3 @@
+#!/bin/bash
+cd $(dirname "$BASH_SOURCE")
 ./Release_Visualisation/Boids_Partitioning "../../examples/Boids_Partitioning/iterations/0.xml"

--- a/bin/linux-x64/CirclesBruteForce_double.sh
+++ b/bin/linux-x64/CirclesBruteForce_double.sh
@@ -1,1 +1,3 @@
+#!/bin/bash
+cd $(dirname "$BASH_SOURCE")
 ./Release_Console/CirclesBruteForce_double "../../examples/CirclesBruteForce_double/iterations/0.xml" 1

--- a/bin/linux-x64/CirclesBruteForce_float.sh
+++ b/bin/linux-x64/CirclesBruteForce_float.sh
@@ -1,1 +1,3 @@
+#!/bin/bash
+cd $(dirname "$BASH_SOURCE")
 ./Release_Console/CirclesBruteForce_float "../../examples/CirclesBruteForce_float/iterations/0.xml" 1

--- a/bin/linux-x64/CirclesPartitioning_double.sh
+++ b/bin/linux-x64/CirclesPartitioning_double.sh
@@ -1,1 +1,3 @@
+#!/bin/bash
+cd $(dirname "$BASH_SOURCE")
 ./Release_Console/CirclesPartitioning_double "../../examples/CirclesPartitioning_double/iterations/0.xml" 1

--- a/bin/linux-x64/CirclesPartitioning_float.sh
+++ b/bin/linux-x64/CirclesPartitioning_float.sh
@@ -1,1 +1,3 @@
+#!/bin/bash
+cd $(dirname "$BASH_SOURCE")
 ./Release_Console/CirclesPartitioning_float "../../examples/CirclesPartitioning_float/iterations/0.xml" 1

--- a/bin/linux-x64/EmptyExample_console.sh
+++ b/bin/linux-x64/EmptyExample_console.sh
@@ -1,2 +1,3 @@
+#!/bin/bash
+cd $(dirname "$BASH_SOURCE")
 ./Release_Console/EmptyExample "../../examples/EmptyExample/iterations/0.xml" 1
-pause;

--- a/bin/linux-x64/EmptyExample_visualisation.sh
+++ b/bin/linux-x64/EmptyExample_visualisation.sh
@@ -1,1 +1,3 @@
+#!/bin/bash
+cd $(dirname "$BASH_SOURCE")
 ./Release_Visualisation/EmptyExample "../../examples/EmptyExample/iterations/0.xml"

--- a/bin/linux-x64/GameOfLife_console.sh
+++ b/bin/linux-x64/GameOfLife_console.sh
@@ -1,1 +1,3 @@
+#!/bin/bash
+cd $(dirname "$BASH_SOURCE")
 ./Release_Console/GameOfLife "../../examples/GameOfLife/iterations/0.xml" 1

--- a/bin/linux-x64/GameOfLife_visualisation.sh
+++ b/bin/linux-x64/GameOfLife_visualisation.sh
@@ -1,1 +1,3 @@
+#!/bin/bash
+cd $(dirname "$BASH_SOURCE")
 ./Release_Visualisation/GameOfLife "../../examples/GameOfLife/iterations/0.xml"

--- a/bin/linux-x64/HostAgentCreation.sh
+++ b/bin/linux-x64/HostAgentCreation.sh
@@ -1,1 +1,3 @@
+#!/bin/bash
+cd $(dirname "$BASH_SOURCE")
 ./Release_Console/HostAgentCreation "../../examples/HostAgentCreation/iterations/0.xml" 1

--- a/bin/linux-x64/Keratinocyte_console.sh
+++ b/bin/linux-x64/Keratinocyte_console.sh
@@ -1,1 +1,3 @@
-./Release_Console/keratinocyte "../../examples/Keratinocyte/iterations/0.xml" 1
+#!/bin/bash
+cd $(dirname "$BASH_SOURCE")
+./Release_Console/Keratinocyte "../../examples/Keratinocyte/iterations/0.xml" 1

--- a/bin/linux-x64/Keratinocyte_visualisation.sh
+++ b/bin/linux-x64/Keratinocyte_visualisation.sh
@@ -1,1 +1,3 @@
-./Release_Visualisation/keratinocyte "../../examples/Keratinocyte/iterations/0.xml"
+#!/bin/bash
+cd $(dirname "$BASH_SOURCE")
+./Release_Visualisation/Keratinocyte "../../examples/Keratinocyte/iterations/0.xml"

--- a/bin/linux-x64/MCBatch_console.sh
+++ b/bin/linux-x64/MCBatch_console.sh
@@ -1,1 +1,0 @@
-./Release_Console/MCBatch "../../examples/MonteCarlo_BATCH/iterations/0.xml" 50

--- a/bin/linux-x64/MC_MSMPR_console.sh
+++ b/bin/linux-x64/MC_MSMPR_console.sh
@@ -1,1 +1,0 @@
-./Release_Console/MC_MSMPR "../../examples/MonteCarlo_MSMPR/iterations/0.xml" 1000

--- a/bin/linux-x64/MonteCarlo_BATCH_console.sh
+++ b/bin/linux-x64/MonteCarlo_BATCH_console.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd $(dirname "$BASH_SOURCE")
+./Release_Console/MonteCarlo_BATCH "../../examples/MonteCarlo_BATCH/iterations/0.xml" 50

--- a/bin/linux-x64/MonteCarlo_MSMPR_console.sh
+++ b/bin/linux-x64/MonteCarlo_MSMPR_console.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd $(dirname "$BASH_SOURCE")
+./Release_Console/MonteCarlo_MSMPR "../../examples/MonteCarlo_MSMPR/iterations/0.xml" 1000

--- a/bin/linux-x64/PedestrainLOD_console.sh
+++ b/bin/linux-x64/PedestrainLOD_console.sh
@@ -1,1 +1,3 @@
+#!/bin/bash
+cd $(dirname "$BASH_SOURCE")
 ./Release_Console/PedestrianLOD "../../examples/PedestrianLOD/iterations/0.xml" 1

--- a/bin/linux-x64/PedestrainLOD_visualisation.sh
+++ b/bin/linux-x64/PedestrainLOD_visualisation.sh
@@ -1,1 +1,3 @@
+#!/bin/bash
+cd $(dirname "$BASH_SOURCE")
 ./Release_Visualisation/PedestrianLOD "../../examples/PedestrianLOD/iterations/0.xml"

--- a/bin/linux-x64/PedestrainNavigation_console.sh
+++ b/bin/linux-x64/PedestrainNavigation_console.sh
@@ -1,1 +1,3 @@
+#!/bin/bash
+cd $(dirname "$BASH_SOURCE")
 ./Release_Console/PedestrianNavigation "../../examples/PedestrianNavigation/iterations/map.xml" 1

--- a/bin/linux-x64/PedestrainNavigation_visualisation.sh
+++ b/bin/linux-x64/PedestrainNavigation_visualisation.sh
@@ -1,1 +1,3 @@
+#!/bin/bash
+cd $(dirname "$BASH_SOURCE")
 ./Release_Visualisation/PedestrianNavigation "../../examples/PedestrianNavigation/iterations/map.xml"

--- a/bin/linux-x64/StableMarriage.sh
+++ b/bin/linux-x64/StableMarriage.sh
@@ -1,1 +1,3 @@
+#!/bin/bash
+cd $(dirname "$BASH_SOURCE")
 ./Release_Console/StableMarriage "../../examples/StableMarriage/iterations/0.xml" 3166

--- a/bin/linux-x64/Sugarscape_console.sh
+++ b/bin/linux-x64/Sugarscape_console.sh
@@ -1,1 +1,3 @@
-./Release_Console/sugarscape "../../examples/Sugarscape/iterations/0.xml" 1
+#!/bin/bash
+cd $(dirname "$BASH_SOURCE")
+./Release_Console/Sugarscape "../../examples/Sugarscape/iterations/0.xml" 1

--- a/bin/linux-x64/Sugarscape_visualisation.sh
+++ b/bin/linux-x64/Sugarscape_visualisation.sh
@@ -1,1 +1,3 @@
-./Release_Visualisation/sugarscape "../../examples/Sugarscape/iterations/0.xml"
+#!/bin/bash
+cd $(dirname "$BASH_SOURCE")
+./Release_Visualisation/Sugarscape "../../examples/Sugarscape/iterations/0.xml"


### PR DESCRIPTION
Fixes several minor issues with FLAME GPU discovered on the HPC facilities at sheffield.

+ Compiler warning using CUDA 8.0 and below
+ Shell scripts could only be called from the `bin/linux-x64` directory