### PR TITLE
Downgrade array element mismatch error to a warning

### DIFF
--- a/FLAMEGPU/templates/io.xslt
+++ b/FLAMEGPU/templates/io.xslt
@@ -76,7 +76,7 @@ void readArrayInput( T (*parseFunc)(const char*), char* buffer, T *array, unsign
     token = strtok_r(buffer, s, &amp;end_str);
     while (token != NULL){
         if (i>=expected_items){
-            printf("Error: variable array %s-&gt;%s has too many items (%d), expected %d!\n", agent_name, variable_name, i, expected_items);
+            fprintf(stderr, "Error: variable array %s-&gt;%s has too many items (%d), expected %d!\n", agent_name, variable_name, i, expected_items);
             exit(EXIT_FAILURE);
         }
         
@@ -84,10 +84,12 @@ void readArrayInput( T (*parseFunc)(const char*), char* buffer, T *array, unsign
         
         token = strtok_r(NULL, s, &amp;end_str);
     }
+    #if ! defined(SUPPRESS_VARIABLE_ARRAY_ELEMENT_WARNING)
     if (i != expected_items){
-        printf("Error: variable array %s-&gt;%s has %d items, expected %d!\n", agent_name, variable_name, i, expected_items);
-        exit(EXIT_FAILURE);
+        fprintf(stderr, "Warning: variable array %s-&gt;%s has %d items, expected %d!\n", agent_name, variable_name, i, expected_items);
+        <!-- exit(EXIT_FAILURE); -->
     }
+    #endif
 }
 
 //templated class function to read array inputs from supported types
@@ -101,7 +103,7 @@ void readArrayInputVectorType( BASE_T (*parseFunc)(const char*), char* buffer, T
     token = strtok_r(buffer, s, &amp;end_str);
     while (token != NULL){
         if (i>=expected_items){
-            printf("Error: variable array of vectors %s-&gt;%s has too many items (%d), expected %d!\n", agent_name, variable_name, i, expected_items);
+            fprintf(stderr, "Error: variable array of vectors %s-&gt;%s has too many items (%d), expected %d!\n", agent_name, variable_name, i, expected_items);
         }
         
         //read vector type as an array
@@ -111,10 +113,12 @@ void readArrayInputVectorType( BASE_T (*parseFunc)(const char*), char* buffer, T
         
         token = strtok_r(NULL, s, &amp;end_str);
     }
+    #if ! defined(SUPPRESS_VARIABLE_ARRAY_ELEMENT_WARNING)
     if (i != expected_items){
-        printf("Error: variable array of vectors %s-&gt;%s has %d items, expected %d!\n", agent_name, variable_name, i, expected_items);
-        exit(EXIT_FAILURE);
+        fprintf(stderr, "Warning: variable array of vectors %s-&gt;%s has %d items, expected %d!\n", agent_name, variable_name, i, expected_items);
+        <!-- exit(EXIT_FAILURE); -->
     }
+    #endif
 }
 
 void saveIterationData(char* outputpath, int iteration_number, <xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent/xmml:states/gpu:state">xmachine_memory_<xsl:value-of select="../../xmml:name"/>_list* h_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:name"/>, xmachine_memory_<xsl:value-of select="../../xmml:name"/>_list* d_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:name"/>, int h_xmachine_memory_<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>_count<xsl:if test="position()!=last()">,</xsl:if></xsl:for-each>)

--- a/examples/Analytics/Makefile
+++ b/examples/Analytics/Makefile
@@ -51,6 +51,9 @@ EXAMPLE_BUILD_DIR := ./build
 # TRANSFORM_MAIN_XSLT_DISABLED := 1
 # TRANSFORM_VISUALISTION_XSLT_DISABLED := 1
 
+# Optionally pass extra compile time flags
+# DEFINES ?= 
+
 # Include the comman makefile from the tools directory.
 # If you wish to make a standalone project, you can simply replace this line with the contents of the common.mk file
 include $(FLAMEGPU_ROOT)tools/common.mk

--- a/examples/Boids_BruteForce/Makefile
+++ b/examples/Boids_BruteForce/Makefile
@@ -51,6 +51,9 @@ EXAMPLE_BUILD_DIR := ./build
 # TRANSFORM_MAIN_XSLT_DISABLED := 1
 # TRANSFORM_VISUALISTION_XSLT_DISABLED := 1
 
+# Optionally pass extra compile time flags
+# DEFINES ?= 
+
 # Include the comman makefile from the tools directory.
 # If you wish to make a standalone project, you can simply replace this line with the contents of the common.mk file
 include $(FLAMEGPU_ROOT)tools/common.mk

--- a/examples/Boids_Partitioning/Makefile
+++ b/examples/Boids_Partitioning/Makefile
@@ -51,6 +51,9 @@ EXAMPLE_BUILD_DIR := ./build
 # TRANSFORM_MAIN_XSLT_DISABLED := 1
 # TRANSFORM_VISUALISTION_XSLT_DISABLED := 1
 
+# Optionally pass extra compile time flags
+# DEFINES ?= 
+
 # Include the comman makefile from the tools directory.
 # If you wish to make a standalone project, you can simply replace this line with the contents of the common.mk file
 include $(FLAMEGPU_ROOT)tools/common.mk

--- a/examples/Boids_PartitioningVecTypes/Makefile
+++ b/examples/Boids_PartitioningVecTypes/Makefile
@@ -51,6 +51,9 @@ EXAMPLE_BUILD_DIR := ./build
 # TRANSFORM_MAIN_XSLT_DISABLED := 1
 # TRANSFORM_VISUALISTION_XSLT_DISABLED := 1
 
+# Optionally pass extra compile time flags
+# DEFINES ?= 
+
 # Include the comman makefile from the tools directory.
 # If you wish to make a standalone project, you can simply replace this line with the contents of the common.mk file
 include $(FLAMEGPU_ROOT)tools/common.mk

--- a/examples/CirclesBruteForce_double/Makefile
+++ b/examples/CirclesBruteForce_double/Makefile
@@ -51,6 +51,9 @@ EXAMPLE_BUILD_DIR := ./build
 # TRANSFORM_MAIN_XSLT_DISABLED := 1
 # TRANSFORM_VISUALISTION_XSLT_DISABLED := 1
 
+# Optionally pass extra compile time flags
+# DEFINES ?= 
+
 # Include the comman makefile from the tools directory.
 # If you wish to make a standalone project, you can simply replace this line with the contents of the common.mk file
 include $(FLAMEGPU_ROOT)tools/common.mk

--- a/examples/CirclesBruteForce_float/Makefile
+++ b/examples/CirclesBruteForce_float/Makefile
@@ -51,6 +51,9 @@ EXAMPLE_BUILD_DIR := ./build
 # TRANSFORM_MAIN_XSLT_DISABLED := 1
 # TRANSFORM_VISUALISTION_XSLT_DISABLED := 1
 
+# Optionally pass extra compile time flags
+# DEFINES ?= 
+
 # Include the comman makefile from the tools directory.
 # If you wish to make a standalone project, you can simply replace this line with the contents of the common.mk file
 include $(FLAMEGPU_ROOT)tools/common.mk

--- a/examples/CirclesPartitioning_double/Makefile
+++ b/examples/CirclesPartitioning_double/Makefile
@@ -51,6 +51,9 @@ EXAMPLE_BUILD_DIR := ./build
 # TRANSFORM_MAIN_XSLT_DISABLED := 1
 # TRANSFORM_VISUALISTION_XSLT_DISABLED := 1
 
+# Optionally pass extra compile time flags
+# DEFINES ?= 
+
 # Include the comman makefile from the tools directory.
 # If you wish to make a standalone project, you can simply replace this line with the contents of the common.mk file
 include $(FLAMEGPU_ROOT)tools/common.mk

--- a/examples/CirclesPartitioning_float/Makefile
+++ b/examples/CirclesPartitioning_float/Makefile
@@ -51,6 +51,9 @@ EXAMPLE_BUILD_DIR := ./build
 # TRANSFORM_MAIN_XSLT_DISABLED := 1
 # TRANSFORM_VISUALISTION_XSLT_DISABLED := 1
 
+# Optionally pass extra compile time flags
+# DEFINES ?= 
+
 # Include the comman makefile from the tools directory.
 # If you wish to make a standalone project, you can simply replace this line with the contents of the common.mk file
 include $(FLAMEGPU_ROOT)tools/common.mk

--- a/examples/EmptyExample/Makefile
+++ b/examples/EmptyExample/Makefile
@@ -51,6 +51,9 @@ EXAMPLE_BUILD_DIR := ./build
 # TRANSFORM_MAIN_XSLT_DISABLED := 1
 # TRANSFORM_VISUALISTION_XSLT_DISABLED := 1
 
+# Optionally pass extra compile time flags
+# DEFINES ?= 
+
 # Include the comman makefile from the tools directory.
 # If you wish to make a standalone project, you can simply replace this line with the contents of the common.mk file
 include $(FLAMEGPU_ROOT)tools/common.mk

--- a/examples/GameOfLife/Makefile
+++ b/examples/GameOfLife/Makefile
@@ -51,6 +51,9 @@ EXAMPLE_BUILD_DIR := ./build
 # TRANSFORM_MAIN_XSLT_DISABLED := 1
 # TRANSFORM_VISUALISTION_XSLT_DISABLED := 1
 
+# Optionally pass extra compile time flags
+# DEFINES ?= 
+
 # Include the comman makefile from the tools directory.
 # If you wish to make a standalone project, you can simply replace this line with the contents of the common.mk file
 include $(FLAMEGPU_ROOT)tools/common.mk

--- a/examples/HostAgentCreation/Makefile
+++ b/examples/HostAgentCreation/Makefile
@@ -51,6 +51,9 @@ EXAMPLE_BUILD_DIR := ./build
 # TRANSFORM_MAIN_XSLT_DISABLED := 1
 # TRANSFORM_VISUALISTION_XSLT_DISABLED := 1
 
+# Optionally pass extra compile time flags
+# DEFINES ?= 
+
 # Include the comman makefile from the tools directory.
 # If you wish to make a standalone project, you can simply replace this line with the contents of the common.mk file
 include $(FLAMEGPU_ROOT)tools/common.mk

--- a/examples/Keratinocyte/Makefile
+++ b/examples/Keratinocyte/Makefile
@@ -51,6 +51,9 @@ EXAMPLE_BUILD_DIR := ./build
 # TRANSFORM_MAIN_XSLT_DISABLED := 1
 # TRANSFORM_VISUALISTION_XSLT_DISABLED := 1
 
+# Optionally pass extra compile time flags
+# DEFINES ?= 
+
 # Include the comman makefile from the tools directory.
 # If you wish to make a standalone project, you can simply replace this line with the contents of the common.mk file
 include $(FLAMEGPU_ROOT)tools/common.mk

--- a/examples/MonteCarlo_BATCH/Makefile
+++ b/examples/MonteCarlo_BATCH/Makefile
@@ -51,6 +51,9 @@ EXAMPLE_BUILD_DIR := ./build
 # TRANSFORM_MAIN_XSLT_DISABLED := 1
 # TRANSFORM_VISUALISTION_XSLT_DISABLED := 1
 
+# Optionally pass extra compile time flags
+# DEFINES ?= 
+
 # Include the comman makefile from the tools directory.
 # If you wish to make a standalone project, you can simply replace this line with the contents of the common.mk file
 include $(FLAMEGPU_ROOT)tools/common.mk

--- a/examples/MonteCarlo_MSMPR/Makefile
+++ b/examples/MonteCarlo_MSMPR/Makefile
@@ -51,6 +51,9 @@ EXAMPLE_BUILD_DIR := ./build
 # TRANSFORM_MAIN_XSLT_DISABLED := 1
 # TRANSFORM_VISUALISTION_XSLT_DISABLED := 1
 
+# Optionally pass extra compile time flags
+# DEFINES ?= 
+
 # Include the comman makefile from the tools directory.
 # If you wish to make a standalone project, you can simply replace this line with the contents of the common.mk file
 include $(FLAMEGPU_ROOT)tools/common.mk

--- a/examples/PedestrianLOD/Makefile
+++ b/examples/PedestrianLOD/Makefile
@@ -51,6 +51,9 @@ EXAMPLE_BUILD_DIR := ./build
 # TRANSFORM_MAIN_XSLT_DISABLED := 1
 # TRANSFORM_VISUALISTION_XSLT_DISABLED := 1
 
+# Optionally pass extra compile time flags
+# DEFINES ?= 
+
 # Include the comman makefile from the tools directory.
 # If you wish to make a standalone project, you can simply replace this line with the contents of the common.mk file
 include $(FLAMEGPU_ROOT)tools/common.mk

--- a/examples/PedestrianNavigation/Makefile
+++ b/examples/PedestrianNavigation/Makefile
@@ -51,6 +51,9 @@ EXAMPLE_BUILD_DIR := ./build
 # TRANSFORM_MAIN_XSLT_DISABLED := 1
 # TRANSFORM_VISUALISTION_XSLT_DISABLED := 1
 
+# Optionally pass extra compile time flags
+# DEFINES ?= 
+
 # Include the comman makefile from the tools directory.
 # If you wish to make a standalone project, you can simply replace this line with the contents of the common.mk file
 include $(FLAMEGPU_ROOT)tools/common.mk

--- a/examples/RestrictedFlowGraph/Makefile
+++ b/examples/RestrictedFlowGraph/Makefile
@@ -51,6 +51,9 @@ EXAMPLE_BUILD_DIR := ./build
 # TRANSFORM_MAIN_XSLT_DISABLED := 1
 # TRANSFORM_VISUALISTION_XSLT_DISABLED := 1
 
+# Optionally pass extra compile time flags
+# DEFINES ?= 
+
 # Include the comman makefile from the tools directory.
 # If you wish to make a standalone project, you can simply replace this line with the contents of the common.mk file
 include $(FLAMEGPU_ROOT)tools/common.mk

--- a/examples/StableMarriage/Makefile
+++ b/examples/StableMarriage/Makefile
@@ -51,6 +51,9 @@ EXAMPLE_BUILD_DIR := ./build
 # TRANSFORM_MAIN_XSLT_DISABLED := 1
 # TRANSFORM_VISUALISTION_XSLT_DISABLED := 1
 
+# Optionally pass extra compile time flags
+# DEFINES ?= 
+
 # Include the comman makefile from the tools directory.
 # If you wish to make a standalone project, you can simply replace this line with the contents of the common.mk file
 include $(FLAMEGPU_ROOT)tools/common.mk

--- a/examples/Sugarscape/Makefile
+++ b/examples/Sugarscape/Makefile
@@ -51,6 +51,9 @@ EXAMPLE_BUILD_DIR := ./build
 # TRANSFORM_MAIN_XSLT_DISABLED := 1
 # TRANSFORM_VISUALISTION_XSLT_DISABLED := 1
 
+# Optionally pass extra compile time flags
+# DEFINES ?= 
+
 # Include the comman makefile from the tools directory.
 # If you wish to make a standalone project, you can simply replace this line with the contents of the common.mk file
 include $(FLAMEGPU_ROOT)tools/common.mk

--- a/tools/common.mk
+++ b/tools/common.mk
@@ -136,6 +136,11 @@ LDFLAGS     :=
 # By default, the mode type is relase and build director
 Mode_TYPE := Release
 
+# If the user specified any flags, pass them through.
+ifneq ($(DEFINES),)
+$(foreach DEF,$(DEFINES),$(eval NVCCFLAGS += -D$(DEF) ))
+endif
+
 # Release/Debug specific build flags and variables
 ifeq ($(debug),1)
 	NVCCFLAGS += -g -G -DDEBIG -D_DEBUG


### PR DESCRIPTION
Downgrade array element mismatch error to a warning. I.e if enough memory is allocated for 12 integers, but only 1 is provided, elements 1 to 11 will be set to the default value (rather than having to specify all values). 

Can be suppressed by defining SUPPRESS_VARIABLE_ARRAY_ELEMENT_WARNING