### PR TITLE
Implement ID Generation functions on the host and the device.

### DIFF
--- a/FLAMEGPU/templates/_common_templates.xslt
+++ b/FLAMEGPU/templates/_common_templates.xslt
@@ -237,4 +237,32 @@
 </xsl:otherwise>
 </xsl:choose>)</xsl:template>
 
+<!-- Template outputs a non zero value if the type is an integer. -->
+<xsl:template name="typeIsInteger">
+    <xsl:param name="type"/>
+    <xsl:choose>
+        <xsl:when test="$type='short'">true</xsl:when>
+        <xsl:when test="$type='unsigned short'">true</xsl:when>
+        <xsl:when test="$type='int'">true</xsl:when>
+        <xsl:when test="$type='unsigned int'">true</xsl:when>
+        <xsl:when test="$type='long long int'">true</xsl:when>
+        <xsl:when test="$type='unsigned long long int'">true</xsl:when>
+        <xsl:otherwise>false</xsl:otherwise> <!-- if not an integer type, return nothing. -->
+    </xsl:choose>
+</xsl:template>
+
+<!-- Template outputs a non zero value if the type is an integer. -->
+<xsl:template name="maximumIntegerValue">
+    <xsl:param name="type"/>
+    <xsl:choose>
+        <xsl:when test="$type='short'">SHRT_MAX</xsl:when>
+        <xsl:when test="$type='unsigned short'">USHRT_MAX</xsl:when>
+        <xsl:when test="$type='int'">INT_MAX</xsl:when>
+        <xsl:when test="$type='unsigned int'">UINT_MAX</xsl:when>
+        <xsl:when test="$type='long long int'">LLONG_MAX</xsl:when>
+        <xsl:when test="$type='unsigned long long int'">ULLONG_MAX</xsl:when>
+        <xsl:otherwise></xsl:otherwise> <!-- if not an integer type, return nothing. -->
+    </xsl:choose>
+</xsl:template>
+
 </xsl:stylesheet>

--- a/FLAMEGPU/templates/header.xslt
+++ b/FLAMEGPU/templates/header.xslt
@@ -489,6 +489,23 @@ __FLAME_GPU_FUNC__ void set_<xsl:value-of select="xmml:name"/>_agent_array_value
     
 </xsl:for-each>
 
+/* Agent ID Generation functions implemented in simulation.cu and FLAMEGPU_kernals.cu*/
+<xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent">
+<xsl:variable name="agent_name" select="xmml:name" />
+<xsl:for-each select="xmml:memory/gpu:variable">
+<xsl:variable name="variable_name" select="xmml:name" />
+<xsl:variable name="variable_type" select="xmml:type" />
+<xsl:variable name="type_is_integer"><xsl:call-template name="typeIsInteger"><xsl:with-param name="type" select="$variable_type"/></xsl:call-template></xsl:variable>
+<!-- If the agent has a variable name id, of a single integer type -->
+<xsl:if test="$variable_name='id' and not(xmml:arrayLength) and $type_is_integer='true'" >
+extern <xsl:value-of select="$variable_type"/> h_current_value_generate_<xsl:value-of select="$agent_name"/>_id;
+__device__ <xsl:value-of select="$variable_type"/> d_current_value_generate_<xsl:value-of select="$agent_name"/>_id;
+__FLAME_GPU_HOST_FUNC__ __FLAME_GPU_FUNC__ <xsl:value-of select="$variable_type"/> generate_<xsl:value-of select="$agent_name"/>_id();
+void set_initial_<xsl:value-of select="$agent_name"/>_id(<xsl:value-of select="$variable_type" /> firstID);
+</xsl:if>
+</xsl:for-each>
+</xsl:for-each>
+
 /* Graph loading function prototypes implemented in io.cu */
 <xsl:for-each select="gpu:xmodel/gpu:environment/gpu:graphs/gpu:staticGraph">
 <xsl:if test="gpu:loadFromFile/gpu:json">void load_staticGraph_<xsl:value-of select="gpu:name"/>_from_json(const char* file, staticGraph_memory_<xsl:value-of select="gpu:name"/>* h_staticGraph_memory_<xsl:value-of select="gpu:name"/>);

--- a/FLAMEGPU/templates/io.xslt
+++ b/FLAMEGPU/templates/io.xslt
@@ -293,6 +293,21 @@ void readInitialStates(char* inputpath, <xsl:for-each select="gpu:xmodel/xmml:xa
     </xsl:when><xsl:otherwise>env_<xsl:value-of select="xmml:name"/> = <xsl:call-template name="defaultInitialiser"><xsl:with-param name="type" select="xmml:type"/><xsl:with-param name="defaultValue" select="xmml:defaultValue" /></xsl:call-template>;
     </xsl:otherwise></xsl:choose>
     </xsl:for-each>
+
+
+    // Declare and initialise variables tracking the maximum agent id for each agent type from the initial population
+    <xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent">
+    <xsl:variable name="agent_name" select="xmml:name" />
+    <xsl:for-each select="xmml:memory/gpu:variable">
+    <xsl:variable name="variable_name" select="xmml:name" />
+    <xsl:variable name="variable_type" select="xmml:type" />
+    <xsl:variable name="type_is_integer"><xsl:call-template name="typeIsInteger"><xsl:with-param name="type" select="$variable_type"/></xsl:call-template></xsl:variable>
+    <!-- If the agent has a variable name id, of a single integer type -->
+    <xsl:if test="$variable_name='id' and not(xmml:arrayLength) and $type_is_integer='true'" >
+    <xsl:value-of select="$variable_type" /> max_<xsl:value-of select="$agent_name"/>_<xsl:value-of select="$variable_name" /> = 0;
+    </xsl:if>
+    </xsl:for-each>
+    </xsl:for-each>
     
     // If no input path was specified, issue a message and return.
     if(inputpath[0] == '\0'){
@@ -487,6 +502,17 @@ void readInitialStates(char* inputpath, <xsl:for-each select="gpu:xmodel/xmml:xa
                         </xsl:choose>
                       </xsl:otherwise>
                     </xsl:choose>
+                    <!-- If this variable corresponds to an integer id, update the tracked maximum -->
+                    <xsl:variable name="agent_name" select="../../xmml:name" />
+                    <xsl:variable name="variable_name" select="xmml:name" />
+                    <xsl:variable name="variable_type" select="xmml:type" />
+                    <xsl:variable name="type_is_integer"><xsl:call-template name="typeIsInteger"><xsl:with-param name="type" select="$variable_type"/></xsl:call-template></xsl:variable>
+                    <!-- If the agent has a variable name id, of a single integer type -->
+                    <xsl:if test="$variable_name='id' and not(xmml:arrayLength) and $type_is_integer='true'" >
+                    if(<xsl:value-of select="$agent_name"/>_<xsl:value-of select="$variable_name" /> > max_<xsl:value-of select="$agent_name"/>_<xsl:value-of select="$variable_name" />){
+                        max_<xsl:value-of select="$agent_name"/>_<xsl:value-of select="$variable_name" /> = <xsl:value-of select="$agent_name"/>_<xsl:value-of select="$variable_name" />;
+                    }
+                    </xsl:if>
                 }
 				</xsl:for-each>
             }
@@ -565,6 +591,29 @@ void readInitialStates(char* inputpath, <xsl:for-each select="gpu:xmodel/xmml:xa
 
 	/* Close the file */
 	fclose(file);
+
+    // IF required, set the first id value to maximum plus one.
+    <xsl:for-each select="gpu:xmodel/xmml:xagents/gpu:xagent">
+    <xsl:variable name="agent_name" select="xmml:name" />
+    <xsl:for-each select="xmml:memory/gpu:variable">
+    <xsl:variable name="variable_name" select="xmml:name" />
+    <xsl:variable name="variable_type" select="xmml:type" />
+    <xsl:variable name="type_is_integer"><xsl:call-template name="typeIsInteger"><xsl:with-param name="type" select="$variable_type"/></xsl:call-template></xsl:variable>
+    <!-- If the agent has a variable name id, of a single integer type -->
+    <xsl:if test="$variable_name='id' and not(xmml:arrayLength) and $type_is_integer='true'" >
+    // If any agents of this type were found, use the maximum value +1
+    if(h_xmachine_memory_<xsl:value-of select="$agent_name"/>_count > 0){
+        set_initial_<xsl:value-of select="$agent_name"/>_id(max_<xsl:value-of select="$agent_name"/>_<xsl:value-of select="$variable_name" /> + 1);
+
+    } else {
+    // Otherwise use 0.
+        set_initial_<xsl:value-of select="$agent_name"/>_id(0);
+    }
+
+
+    </xsl:if>
+    </xsl:for-each>
+    </xsl:for-each>
 }
 
 glm::vec3 getMaximumBounds(){

--- a/examples/HostAgentCreation/src/model/XMLModelFile.xml
+++ b/examples/HostAgentCreation/src/model/XMLModelFile.xml
@@ -62,6 +62,12 @@
           <name>update</name>
           <currentState>default</currentState>
           <nextState>default</nextState>
+          <xagentOutputs>
+            <gpu:xagentOutput>
+              <xagentName>Agent</xagentName>
+              <state>default</state>
+            </gpu:xagentOutput>
+          </xagentOutputs>
           <gpu:reallocate>true</gpu:reallocate>
           <gpu:RNG>false</gpu:RNG>
         </gpu:function>

--- a/examples/HostAgentCreation/src/model/functions.c
+++ b/examples/HostAgentCreation/src/model/functions.c
@@ -71,7 +71,8 @@ __FLAME_GPU_INIT_FUNC__ void generateAgentInit(){
 	xmachine_memory_Agent * h_agent = h_allocate_agent_Agent();
 
 	// Set values as required for the single agent.
-	h_agent->id = getNextID();
+	h_agent->id = generate_Agent_id();
+	// printf("h_agent->id = %u\n", h_agent->id);
 	h_agent->time_alive = rand() % (*get_MAX_LIFESPAN());
 	for (unsigned int i = 0; i < xmachine_memory_Agent_example_array_LENGTH; i++) {
 		h_agent->example_array[i] = rand() / (double)RAND_MAX;
@@ -108,7 +109,8 @@ __FLAME_GPU_STEP_FUNC__ void generateAgentStep(){
 		}
 		// Populate data as required
 		for (unsigned int i = 0; i < count; i++) {
-			h_agent_AoS[i]->id = getNextID();
+			h_agent_AoS[i]->id = generate_Agent_id();
+			// printf("h_agent_AoS[i]->id = %u\n", h_agent_AoS[i]->id);
 			h_agent_AoS[i]->time_alive = rand() % (*get_MAX_LIFESPAN());
 			for (unsigned int j = 0; j < xmachine_memory_Agent_example_array_LENGTH; j++) {
 				h_agent_AoS[i]->example_array[j] = rand() / (double)RAND_MAX;
@@ -188,8 +190,7 @@ __FLAME_GPU_EXIT_FUNC__ void exitFunction(){
  * Simple agent function, incrementing the time of life of the agent. 
  * If the agent has exceeded the maximum life span, it dies.
  */
-__FLAME_GPU_FUNC__ int update(xmachine_memory_Agent* agent)
-{
+__FLAME_GPU_FUNC__ int update(xmachine_memory_Agent* agent, xmachine_memory_Agent_list* Agent_agents){
 	// Increment time alive
 	agent->time_alive++;
 	/*if(threadIdx.x + blockDim.x * blockIdx.x < 64){
@@ -207,10 +208,16 @@ __FLAME_GPU_FUNC__ int update(xmachine_memory_Agent* agent)
 	}*/
 	// If agent has been alive long enough, kill them.
 	if (agent->time_alive > MAX_LIFESPAN){
+		// Create a new agent, after generating new values
+		unsigned int new_id = generate_Agent_id();
+		// printf("tid %d new_id = %u\n", tid, new_id);
+	    unsigned int new_time_alive = 12;
+	    ivec4 new_example_vector = {0,0,0,0};
+	    
+	    add_Agent_agent(Agent_agents, new_id, new_time_alive, new_example_vector);
 		return 1;
 	}	
 	return 0;
 }
-
 
 #endif // #ifndef _FUNCTIONS_H_


### PR DESCRIPTION
Constrained to only work for agents with a variable 'id', of a singular integer type (short, int, long long) which may or may not be unsigned.

The maximum id from the initial states file is found and used as the first value available in an init function.
The current next id is maintained through host/device memcpys and state tracking to ensure that the correct value is available at the appropriate location.

i.e. for an agent named 'Agent' the function `generate_id_Agent()` can be called in a host or xagentOutput device function to generate a new identifier

Closes #247

Function / variable names can be changed if desired. 