### PR TITLE
Increase limit on path length(s) used by FLAME GPU

### DIFF
--- a/FLAMEGPU/templates/header.xslt
+++ b/FLAMEGPU/templates/header.xslt
@@ -39,6 +39,10 @@
 #define FLAME_GPU_MINOR_VERSION 5
 #define FLAME_GPU_PATCH_VERSION 0
 
+/* Constant definitions */
+// Maximum length file path in windows is 260 (soon to be longer) and 4096 under linux (assuming ext4)
+#define MAX_FILEPATH_LENGTH 4096
+
 typedef unsigned int uint;
 
 //FLAME GPU vector types float, (i)nteger, (u)nsigned integer, (d)ouble

--- a/FLAMEGPU/templates/io.xslt
+++ b/FLAMEGPU/templates/io.xslt
@@ -137,7 +137,7 @@ void saveIterationData(char* outputpath, int iteration_number, <xsl:for-each sel
 	
 	/* Pointer to file */
 	FILE *file;
-	char data[100];
+	char data[MAX_FILEPATH_LENGTH];
 
 	sprintf(data, "%s%i.xml", outputpath, iteration_number);
 	//printf("Writing iteration %i data to %s\n", iteration_number, data);

--- a/FLAMEGPU/templates/main.xslt
+++ b/FLAMEGPU/templates/main.xslt
@@ -22,8 +22,8 @@ unsigned int g_profile_colour_id = 0;
 #endif
 
 /* IO Variables*/
-char inputfile[100];          /**&lt; Input path char buffer*/
-char outputpath[1000];         /**&lt; Output path char buffer*/
+char inputfile[MAX_FILEPATH_LENGTH];          /**&lt; Input path char buffer*/
+char outputpath[MAX_FILEPATH_LENGTH];         /**&lt; Output path char buffer*/
 
 // Define the default value indicating if XML output should be produced or not.
 #define OUTPUT_TO_XML 1


### PR DESCRIPTION
Some paths were limited to 100 chars, others to 1000. 

Now standardised to a preprocessor macro, with a value of `4096`, the maximum supported by the ext4 filesystem. NTFS / windows is currently limited to 260 by default, however this can be disabled through a registry edit on recent windows 10 builds.
