### PR TITLE
Speculative Fix for #258

### DIFF
--- a/FLAMEGPU/templates/FLAMEGPU_kernals.xslt
+++ b/FLAMEGPU/templates/FLAMEGPU_kernals.xslt
@@ -219,10 +219,12 @@ __device__ bool next_cell2D(glm::ivec3* relative_cell)
  * <xsl:value-of select="xmml:name"/> agent reset scan input function
  * @param agents The xmachine_memory_<xsl:value-of select="xmml:name"/>_list agent list
  */
-__global__ void reset_<xsl:value-of select="xmml:name"/>_scan_input(xmachine_memory_<xsl:value-of select="xmml:name"/>_list* agents){
+__global__ void reset_<xsl:value-of select="xmml:name"/>_scan_input(xmachine_memory_<xsl:value-of select="xmml:name"/>_list* agents, int threadCt){
 
 	//global thread index
 	int index = (blockIdx.x*blockDim.x) + threadIdx.x;
+
+    if(index &gt; threadCt) return;
 
 	agents->_position[index] = 0;
 	agents->_scan_input[index] = 0;
@@ -428,10 +430,12 @@ __global__ void scatter_optional_<xsl:value-of select="xmml:name"/>_messages(xma
  * Reset non partitioned or spatially partitioned <xsl:value-of select="xmml:name"/> message swaps (for scattering optional messages)
  * @param message_swap message list to reset _position and _scan_input values back to 0
  */
-__global__ void reset_<xsl:value-of select="xmml:name"/>_swaps(xmachine_message_<xsl:value-of select="xmml:name"/>_list* messages_swap){
+__global__ void reset_<xsl:value-of select="xmml:name"/>_swaps(xmachine_message_<xsl:value-of select="xmml:name"/>_list* messages_swap, int threadCt){
 
 	//global thread index
 	int index = (blockIdx.x*blockDim.x) + threadIdx.x;
+
+    if(index &gt; threadCt) return;
 
 	messages_swap->_position[index] = 0;
 	messages_swap->_scan_input[index] = 0;

--- a/FLAMEGPU/templates/simulation.xslt
+++ b/FLAMEGPU/templates/simulation.xslt
@@ -1426,7 +1426,7 @@ void <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>
 	//FOR <xsl:value-of select="xmml:xagentName"/> AGENT OUTPUT, RESET THE AGENT NEW LIST SCAN INPUT
 	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, reset_<xsl:value-of select="xmml:xagentName"/>_scan_input, no_sm, state_list_size); 
 	gridSize = (state_list_size + blockSize - 1) / blockSize;
-	reset_<xsl:value-of select="xmml:xagentName"/>_scan_input&lt;&lt;&lt;gridSize, blockSize, 0, stream&gt;&gt;&gt;(d_<xsl:value-of select="xmml:xagentName"/>s_new);
+	reset_<xsl:value-of select="xmml:xagentName"/>_scan_input&lt;&lt;&lt;gridSize, blockSize, 0, stream&gt;&gt;&gt;(d_<xsl:value-of select="xmml:xagentName"/>s_new, state_list_size);
 	gpuErrchkLaunch();
 	</xsl:if></xsl:for-each></xsl:if>
 
@@ -1442,10 +1442,10 @@ void <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>
 	//reset scan input for currentState
 	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, reset_<xsl:value-of select="../../xmml:name"/>_scan_input, no_sm, state_list_size); 
 	gridSize = (state_list_size + blockSize - 1) / blockSize;
-	reset_<xsl:value-of select="../../xmml:name"/>_scan_input&lt;&lt;&lt;gridSize, blockSize, 0, stream&gt;&gt;&gt;(d_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:currentState"/>);
+	reset_<xsl:value-of select="../../xmml:name"/>_scan_input&lt;&lt;&lt;gridSize, blockSize, 0, stream&gt;&gt;&gt;(d_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:currentState"/>, state_list_size);
 	gpuErrchkLaunch();
 	//reset scan input for working lists
-	reset_<xsl:value-of select="../../xmml:name"/>_scan_input&lt;&lt;&lt;gridSize, blockSize, 0, stream&gt;&gt;&gt;(d_<xsl:value-of select="../../xmml:name"/>s);
+	reset_<xsl:value-of select="../../xmml:name"/>_scan_input&lt;&lt;&lt;gridSize, blockSize, 0, stream&gt;&gt;&gt;(d_<xsl:value-of select="../../xmml:name"/>s, state_list_size);
 	gpuErrchkLaunch();
 
 	//APPLY FUNCTION FILTER
@@ -1533,7 +1533,7 @@ void <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>
 	//reset scan input for currentState
 	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, reset_<xsl:value-of select="../../xmml:name"/>_scan_input, no_sm, state_list_size); 
 	gridSize = (state_list_size + blockSize - 1) / blockSize;
-	reset_<xsl:value-of select="../../xmml:name"/>_scan_input&lt;&lt;&lt;gridSize, blockSize, 0, stream&gt;&gt;&gt;(d_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:currentState"/>);
+	reset_<xsl:value-of select="../../xmml:name"/>_scan_input&lt;&lt;&lt;gridSize, blockSize, 0, stream&gt;&gt;&gt;(d_<xsl:value-of select="../../xmml:name"/>s_<xsl:value-of select="xmml:currentState"/>, state_list_size);
 	gpuErrchkLaunch();
 	
 	//APPLY FUNCTION FILTER
@@ -1662,7 +1662,7 @@ void <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>
 	<xsl:if test="$outputType='optional_message'">//message is optional so reset the swap
 	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, reset_<xsl:value-of select="xmml:name"/>_swaps, no_sm, state_list_size); 
 	gridSize = (state_list_size + blockSize - 1) / blockSize;
-	reset_<xsl:value-of select="xmml:name"/>_swaps&lt;&lt;&lt;gridSize, blockSize, 0, stream&gt;&gt;&gt;(d_<xsl:value-of select="xmml:name"/>s); <!-- Twin Karmakharm Change - Bug found, need to reset the actual message array and not the swap array -->
+	reset_<xsl:value-of select="xmml:name"/>_swaps&lt;&lt;&lt;gridSize, blockSize, 0, stream&gt;&gt;&gt;(d_<xsl:value-of select="xmml:name"/>s, state_list_size); <!-- Twin Karmakharm Change - Bug found, need to reset the actual message array and not the swap array -->
 	gpuErrchkLaunch();
 	</xsl:if></xsl:if></xsl:for-each>
 	</xsl:if></xsl:if>
@@ -1672,7 +1672,7 @@ void <xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>
 	//IF CONTINUOUS AGENT CAN REALLOCATE (process dead agents) THEN RESET AGENT SWAPS	
 	cudaOccupancyMaxPotentialBlockSizeVariableSMem( &amp;minGridSize, &amp;blockSize, reset_<xsl:value-of select="../../xmml:name"/>_scan_input, no_sm, state_list_size); 
 	gridSize = (state_list_size + blockSize - 1) / blockSize;
-	reset_<xsl:value-of select="../../xmml:name"/>_scan_input&lt;&lt;&lt;gridSize, blockSize, 0, stream&gt;&gt;&gt;(d_<xsl:value-of select="../../xmml:name"/>s);
+	reset_<xsl:value-of select="../../xmml:name"/>_scan_input&lt;&lt;&lt;gridSize, blockSize, 0, stream&gt;&gt;&gt;(d_<xsl:value-of select="../../xmml:name"/>s, state_list_size);
 	gpuErrchkLaunch();
 	</xsl:if></xsl:if>
 	


### PR DESCRIPTION
Looking into the issue, noticed message scan 'reset' kernels don't bound threads to agent count.

Checked that it builds Boids_Partitioning and Boids_BruteForce

Passes the intended launch size to 'memset' kernels to bound threads. Note its resetting according to agents within state, rather than all agents. Not sure if this is significant.

Passed launch size, as unsure could grab correct state inside kernel definition's xslt to use the value already in device memory.

---

Pete should check whether this fixes #258, but regardless it seems like a necessary improvement.