### PR TITLE
Added doi, fixed broken link to old site.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -147,6 +147,7 @@ Please cite FLAME GPU using
 
 ```
 @article{richmond2010high,
+  doi={10.1093/bib/bbp073},
   title={High performance cellular level agent-based simulation with FLAME for the GPU},
   author={Richmond, Paul and Walker, Dawn and Coakley, Simon and Romano, Daniela},
   journal={Briefings in bioinformatics},
@@ -158,7 +159,7 @@ Please cite FLAME GPU using
 }
 ```
 
-For an up to date list of publications related to FLAME GPU and it's use, [visit the flamegpu.com website](http://flamegpu.com).
+For an up to date list of publications related to FLAME GPU and it's use, [visit the flamegpu.com website](http://www.flamegpu.com).
 
 
 ## Authors


### PR DESCRIPTION
1. doi in ref enables easy access eg via Sci-Hub or Library Genesis as well as to publisher site.
2. Omitting www prefix should work but was giving 404 error no such site.
3. Both versions should presumably point to new site:
https://flamegpu.github.io/
If that is ready it should be fixed in its repo and/or DNS records.