### PR TITLE
Add compiler time #error if layerFunction mentions an invalid agent functon

### DIFF
--- a/FLAMEGPU/templates/simulation.xslt
+++ b/FLAMEGPU/templates/simulation.xslt
@@ -898,7 +898,11 @@ PROFILE_SCOPED_RANGE("singleIteration");
 #if defined(INSTRUMENT_AGENT_FUNCTIONS) &amp;&amp; INSTRUMENT_AGENT_FUNCTIONS
 	cudaEventRecord(instrument_start);
 #endif
-	<xsl:variable name="function" select="xmml:name"/><xsl:variable name="stream_num" select="position()"/><xsl:for-each select="../../../xmml:xagents/gpu:xagent/xmml:functions/gpu:function[xmml:name=$function]">
+	<xsl:variable name="function" select="xmml:name"/><xsl:variable name="stream_num" select="position()"/>
+	<xsl:choose><xsl:when test="../../../xmml:xagents/gpu:xagent/xmml:functions/gpu:function[xmml:name=$function]"></xsl:when>
+	<xsl:otherwise>#error "Layer <xsl:value-of select="position()"/> contains layerFunction '<xsl:value-of select="$function" />' which is not defined by any agent type."
+	</xsl:otherwise></xsl:choose>
+	<xsl:for-each select="../../../xmml:xagents/gpu:xagent/xmml:functions/gpu:function[xmml:name=$function]">
     PROFILE_PUSH_RANGE("<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>");
 	<xsl:value-of select="../../xmml:name"/>_<xsl:value-of select="xmml:name"/>(stream<xsl:value-of select="$stream_num"/>);
     PROFILE_POP_RANGE();


### PR DESCRIPTION
If xslt validation does not occur (if xmllint is unavailble or on windows) it's possible to include agent functions in layers, which are not defined by any agent. 

This can lead to unexpected behaviour, where a uses has defined and written a function, but it does not get called. 

This PR causes a compile time error in that case.



This is for when xml validation is not available, otherwise compilation succeeds in producing a usable but likely unintended model